### PR TITLE
Make code mypy clean

### DIFF
--- a/examples/anisotropic_grating.py
+++ b/examples/anisotropic_grating.py
@@ -70,7 +70,7 @@ def simulate_grating(
     density = grating_density(pitch_nm, grating_width_nm, resolution_nm)
     permittivities_grating = [
         utils.interpolate_permittivity(
-            permittivity_solid=pt, permittivity_void=pg, density=density
+            permittivity_solid=pt, permittivity_void=pg, density=density  # type: ignore[arg-type]
         )
         for pt, pg in zip(permittivities_grating_tooth, permittivities_grating_gap)
     ]
@@ -120,17 +120,17 @@ def simulate_grating(
             wavelength_nm,
             in_plane_wavevector,
             primitive_lattice_vectors,
-            *permittivities_grating,
-            expansion=expansion,
-            formulation=fmm.Formulation.FFT,
+            *permittivities_grating,  # type: ignore[arg-type]
+            expansion=expansion,  # type: ignore[misc]
+            formulation=fmm.Formulation.FFT,  # type: ignore[misc]
         ),
         layer.eigensolve_anisotropic_media(
             wavelength_nm,
             in_plane_wavevector,
             primitive_lattice_vectors,
-            *permittivities_substrate,
-            expansion=expansion,
-            formulation=fmm.Formulation.FFT,
+            *permittivities_substrate,  # type: ignore[arg-type]
+            expansion=expansion,  # type: ignore[misc]
+            formulation=fmm.Formulation.FFT,  # type: ignore[misc]
         ),
     ]
 

--- a/examples/ar_coating.py
+++ b/examples/ar_coating.py
@@ -7,7 +7,7 @@ from typing import Sequence, Tuple
 
 import jax.numpy as jnp
 import numpy as onp
-import scipy.optimize as spo
+import scipy.optimize as spo  # type: ignore[import]
 
 from fmmax import basis, layer, scattering
 

--- a/examples/sorter.py
+++ b/examples/sorter.py
@@ -251,15 +251,13 @@ def _simulate_polarization_sorter(
         substrate_permittivity[jnp.newaxis, jnp.newaxis],
     ]
 
-    thicknesses = jnp.asarray(
-        [
-            params["layers"]["ambient"]["thickness"],
-            params["layers"]["cap"]["thickness"],
-            params["layers"]["sorter"]["thickness"],
-            params["layers"]["spacer"]["thickness"],
-            params["layers"]["substrate"]["thickness"],
-        ]
-    )
+    thicknesses = [
+        params["layers"]["ambient"]["thickness"],
+        params["layers"]["cap"]["thickness"],
+        params["layers"]["sorter"]["thickness"],
+        params["layers"]["spacer"]["thickness"],
+        params["layers"]["substrate"]["thickness"],
+    ]
 
     # Perform the eigensolve for each layer in the stack.
     layer_solve_results = [

--- a/examples/uled.py
+++ b/examples/uled.py
@@ -178,7 +178,7 @@ def simulate_uled(
         for offset in dipole_y_offset
     ]
     dipoles = sources.gaussian_source(
-        fwhm=dipole_fwhm,
+        fwhm=jnp.asarray(dipole_fwhm),
         location=jnp.asarray(dipole_locations),
         in_plane_wavevector=in_plane_wavevector,
         primitive_lattice_vectors=primitive_lattice_vectors,

--- a/fmmax/fmm.py
+++ b/fmmax/fmm.py
@@ -192,10 +192,7 @@ def _transverse_permittivity_vector(
     delta_matrix = jnp.block([[delta_hat, zeros], [zeros, delta_hat]])
 
     vector_fn = vector.VECTOR_FIELD_SCHEMES[formulation.value]
-    tx, ty = vector_fn(
-        arr=permittivity,
-        primitive_lattice_vectors=primitive_lattice_vectors,
-    )
+    tx, ty = vector_fn(permittivity, primitive_lattice_vectors)
 
     Pxx, Pxy, Pyx, Pyy = tangent_terms(tx, ty)
     p_matrix = jnp.block(
@@ -303,7 +300,7 @@ def fft(
     Returns:
         The transformed `x`.
     """
-    axes = utils.absolute_axes(axes, x.ndim)
+    axes: Tuple[int, int] = utils.absolute_axes(axes, x.ndim)  # type: ignore[no-redef]
     _validate_shape_for_expansion(tuple([x.shape[ax] for ax in axes]), expansion)
 
     x_fft = jnp.fft.fft2(x, axes=axes, norm="forward")

--- a/fmmax/sources.py
+++ b/fmmax/sources.py
@@ -46,7 +46,7 @@ def amplitudes_for_fields(
         )
 
     batch_shape = layer_solve_result.batch_shape
-    brillouin_grid_axes = utils.absolute_axes(brillouin_grid_axes, len(batch_shape))
+    brillouin_grid_axes: Tuple[int, int] = utils.absolute_axes(brillouin_grid_axes, len(batch_shape))  # type: ignore[no-redef]
     brillouin_grid_shape = (
         batch_shape[brillouin_grid_axes[0]],
         batch_shape[brillouin_grid_axes[1]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ dependencies = [
   "jax",
   "jaxlib",
   "numpy",
-  "parameterized",
+  "scipy",
 ]
 
 [project.optional-dependencies]
-test = ["black", "isort", "grcwa"]
+tests = ["grcwa", "parameterized", "pytest"]
+dev = ["black", "fmmax[tests]", "isort", "mypy"]
 
 [tool.setuptools]
 

--- a/tests/fmmax/farfield_test.py
+++ b/tests/fmmax/farfield_test.py
@@ -11,16 +11,8 @@ import jax.numpy as jnp
 import numpy as onp
 import parameterized
 
-from fmmax import (
-    basis,
-    farfield,
-    fields,
-    fmm,
-    layer,
-    scattering,
-    sources,
-    utils,
-)
+from fmmax import (basis, farfield, fields, fmm, layer, scattering, sources,
+                   utils)
 
 
 class FarfieldProfileTest(unittest.TestCase):
@@ -81,7 +73,7 @@ class FarfieldProfileTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=(0, 1),
+            brillouin_grid_axes=(0, 1),
         )
         # Sum the farfield contributions from the two polarizations, and normalize.
         farfield_flux = jnp.sum(farfield_flux, axis=-2)
@@ -117,12 +109,12 @@ class FarfieldProfileTest(unittest.TestCase):
         )
     )
     def test_farfield_integral_in_different_domains(
-        self, batch_shape, brillouin_zone_axes, polar_angle_cutoff
+        self, batch_shape, brillouin_grid_axes, polar_angle_cutoff
     ):
         # Checks that the farfield can be computed for a variety of batch
         # shapes and brillouin zone axes. Also checks that the integral of
         # flux in k space and in the angular domain agree.
-        absolute_axes = utils.absolute_axes(brillouin_zone_axes, len(batch_shape) + 2)
+        absolute_axes = utils.absolute_axes(brillouin_grid_axes, len(batch_shape) + 2)
 
         # Compute shapes of dummy variables.
         wavelength_shape = tuple(
@@ -175,7 +167,7 @@ class FarfieldProfileTest(unittest.TestCase):
         # Integrate the flux over k-space. The differential area element in
         # k-space is independent of k.
         integrated_flux_k_space = jnp.sum(
-            jnp.where(k_space_mask, flux, 0), axis=brillouin_zone_axes + (-2,)
+            jnp.where(k_space_mask, flux, 0), axis=brillouin_grid_axes + (-2,)
         )
 
         # Compute the farfield angles, solid angle, and associated flux.
@@ -190,7 +182,7 @@ class FarfieldProfileTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=brillouin_zone_axes,
+            brillouin_grid_axes=brillouin_grid_axes,
         )
         farfield_flux = jnp.where(jnp.isnan(farfield_flux), 0, farfield_flux)
         solid_angle = solid_angle[..., jnp.newaxis, jnp.newaxis]
@@ -228,7 +220,7 @@ class IntegratedFluxTest(unittest.TestCase):
         )
     )
     def test_integrated_flux_matches_direct_calculation(
-        self, batch_shape, brillouin_zone_axes, num_sources, upsample_factor
+        self, batch_shape, brillouin_grid_axes, num_sources, upsample_factor
     ):
         # Checks that the calculation of integrated flux "directly" matches that
         # when calcuated by first computing weights, and then taking the inner
@@ -247,15 +239,15 @@ class IntegratedFluxTest(unittest.TestCase):
         )
         wavelength = jax.random.uniform(
             jax.random.PRNGKey(1),
-            [(1 if i in brillouin_zone_axes else d) for i, d in enumerate(batch_shape)],
+            [(1 if i in brillouin_grid_axes else d) for i, d in enumerate(batch_shape)],
         )
         in_plane_wavevector = basis.brillouin_zone_in_plane_wavevector(
-            brillouin_grid_shape=tuple([batch_shape[i] for i in brillouin_zone_axes]),
+            brillouin_grid_shape=tuple([batch_shape[i] for i in brillouin_grid_axes]),
             primitive_lattice_vectors=primitive_lattice_vectors,
         )
         in_plane_wavevector = jnp.expand_dims(
             in_plane_wavevector,
-            axis=[i for i in range(len(batch_shape)) if i not in brillouin_zone_axes],
+            axis=[i for i in range(len(batch_shape)) if i not in brillouin_grid_axes],
         )
 
         def angle_bounds_fn(polar_angle, azimuthal_angle):
@@ -271,7 +263,7 @@ class IntegratedFluxTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=brillouin_zone_axes,
+            brillouin_grid_axes=brillouin_grid_axes,
             angle_bounds_fn=angle_bounds_fn,
             upsample_factor=upsample_factor,
         )
@@ -283,7 +275,7 @@ class IntegratedFluxTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=brillouin_zone_axes,
+            brillouin_grid_axes=brillouin_grid_axes,
             angle_bounds_fn=angle_bounds_fn,
             upsample_factor=upsample_factor,
         )
@@ -318,7 +310,7 @@ class IntegratedFluxTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=(0, 1),
+            brillouin_grid_axes=(0, 1),
             angle_bounds_fn=angle_bounds_fn,
         )
         integrated_flux_no_upsample = integrated_flux_fn(upsample_factor=1)
@@ -390,7 +382,7 @@ class IntegratedFluxTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=(0, 1),
+            brillouin_grid_axes=(0, 1),
         )
 
         integrated_flux = farfield.integrated_flux(
@@ -399,7 +391,7 @@ class IntegratedFluxTest(unittest.TestCase):
             in_plane_wavevector=in_plane_wavevector,
             primitive_lattice_vectors=primitive_lattice_vectors,
             expansion=expansion,
-            brillouin_zone_axes=(0, 1),
+            brillouin_grid_axes=(0, 1),
             angle_bounds_fn=lambda polar_angle, _: jnp.full(polar_angle.shape, True),
             upsample_factor=10,
         )


### PR DESCRIPTION
- updates to pyproject.toml
- Changes to code to make it mypy clean
- Settle on `brillouin_grid_axes` as the var name giving brillouin zone axes. Previously, we used `brillouin_zone_axes` in some palces.