### PR TITLE
Fix pyproject.toml

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint Python files
         run: |
           find . -name "*.py" | xargs black --check
-          find . -name "*.py" | xargs isort --profile black --check-only
+          find . -name "*.py" | xargs isort --profile black --check-onlys
 
       - name: Validate docstrings
         run: |
@@ -43,4 +43,5 @@ jobs:
         
       - name: Run Python tests
         run: |
-          python -m pytest
+          pytest tests/fmmax
+          python -m pytest tests/examples

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint Python files
         run: |
           find . -name "*.py" | xargs black --check
-          find . -name "*.py" | xargs isort --profile black --check-onlys
+          find . -name "*.py" | xargs isort --profile black --check-only
 
       - name: Validate docstrings
         run: |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Vector FMM formulations introduce local coordinate systems at each point in the 
 ## Batching
 Batched calculations are supported, and should be used where possible to avoid looping. The batch axes are the leading axes, except for the wave amplitudes and electromagnetic fields, where a trailing batch axis is assumed. This allows e.g. computing the transmission through a structure for multiple polarizations via a matrix-matrix operation (`transmitted_amplitudes = S11 @ incident_amplitudes`), rather than a batched matrix-vector operation.
 
+## Installation
+
+FMMAX can be installed via pip:
+```
+pip install fmmax
+```
+
 ## Citing FMMAX
 
 If you use FMMAX, please consider citing our paper,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ tests = ["grcwa", "parameterized", "pytest"]
 examples = ["matplotlib", "scikit-image", "scipy"]
 dev = ["black", "darglint", "fmmax[examples, tests]", "isort", "mypy"]
 
-[tool.setuptools]
-py-modules = ["fmmax"]
+[tool.setuptools.packages.find]
+include=["fmmax*"]
 
 [build-system]
 requires = ["setuptools>=43.0.0", "wheel"]


### PR DESCRIPTION
The existing pyproject.toml does not allow proper pip install of fmmax. This PR fixes the file and also updates CI so that it should fail if we again have a situation where pip install is broken.