### PR TITLE
Improve parallelogramic basis

### DIFF
--- a/fmmax/basis.py
+++ b/fmmax/basis.py
@@ -298,9 +298,7 @@ def _basis_coefficients_circular(
     # of `u` and `v` scaled by `num_terms`.
     max_magnitude = onp.sqrt(
         approximate_num_terms
-        * onp.abs(
-            _cross_product(reciprocal_vectors.u, reciprocal_vectors.v)
-        )
+        * onp.abs(_cross_product(reciprocal_vectors.u, reciprocal_vectors.v))
         / onp.pi
     )
     mask = magnitude < max_magnitude
@@ -348,7 +346,7 @@ def _basis_coefficients_parallelogramic(
     # (Note that while the sides of the parallelogram have equal length, the number of
     # points along each direction will differ, as these are spaced by `ku_spacing` and
     # `kv_spacing`.)
-    
+
     def _solve_quadratic(ratio):
         a = 4 * ratio
         b = 2 * (ratio + 1)

--- a/fmmax/basis.py
+++ b/fmmax/basis.py
@@ -354,7 +354,7 @@ def _basis_coefficients_parallelogramic(
         b = 2 * (ratio + 1)
         c = 1 - approximate_num_terms
         nu = (-b + onp.sqrt(b**2 - 4 * a * c)) / (2 * a)
-        return onp.around(nu)
+        return int(onp.around(nu))
 
     nu = _solve_quadratic(ku_spacing / kv_spacing)
     nv = _solve_quadratic(kv_spacing / ku_spacing)

--- a/fmmax/basis.py
+++ b/fmmax/basis.py
@@ -260,7 +260,7 @@ def transverse_wavevectors(
 
 
 def _basis_coefficients_circular(
-    primitive_lattice_vectors: LatticeVectors,
+    reciprocal_vectors: LatticeVectors,
     approximate_num_terms: int,
 ) -> onp.ndarray:
     """Computes the basis coefficients of lattice vectors lying within a circle.
@@ -271,7 +271,7 @@ def _basis_coefficients_circular(
     the set will generally be close to `approximate_num_terms`.
 
     Args:
-        primitive_lattice_vectors: The primitive vectors for the real-space lattice.
+        reciprocal_vectors: The primitive vectors for the reciprocal-space lattice.
         approximate_num_terms: The approximate number of terms in the expansion. To
             maintain a symmetric expansion, the total number of terms may differ from
             this value.
@@ -289,8 +289,8 @@ def _basis_coefficients_circular(
 
     # Generate the actual vectors and compute their magnitude.
     vectors = (
-        G1[..., onp.newaxis] * primitive_lattice_vectors.u[..., onp.newaxis, :]
-        + G2[..., onp.newaxis] * primitive_lattice_vectors.v[..., onp.newaxis, :]
+        G1[..., onp.newaxis] * reciprocal_vectors.u[..., onp.newaxis, :]
+        + G2[..., onp.newaxis] * reciprocal_vectors.v[..., onp.newaxis, :]
     )
     magnitude = onp.linalg.norm(vectors, axis=-1)
 
@@ -299,7 +299,7 @@ def _basis_coefficients_circular(
     max_magnitude = onp.sqrt(
         approximate_num_terms
         * onp.abs(
-            _cross_product(primitive_lattice_vectors.u, primitive_lattice_vectors.v)
+            _cross_product(reciprocal_vectors.u, reciprocal_vectors.v)
         )
         / onp.pi
     )
@@ -315,7 +315,7 @@ def _basis_coefficients_circular(
 
 
 def _basis_coefficients_parallelogramic(
-    primitive_lattice_vectors: LatticeVectors,
+    reciprocal_vectors: LatticeVectors,
     approximate_num_terms: int,
 ) -> onp.ndarray:
     """Computes the basis coefficients of lattice vectors lying within a parallelogram.
@@ -325,7 +325,7 @@ def _basis_coefficients_parallelogramic(
     `approximate_num_terms`.
 
     Args:
-        primitive_lattice_vectors: The primitive vectors for the real-space lattice.
+        reciprocal_vectors: The primitive vectors for the reciprocal-space lattice.
         approximate_num_terms: The approximate number of terms in the expansion. To
             maintain a full parallelogram expansion, the total number of terms may
             differ from this value.
@@ -335,25 +335,42 @@ def _basis_coefficients_parallelogramic(
         coefficient for the first and second vector in the basis.
     """
 
-    u_magnitude = onp.sqrt(onp.sum(onp.abs(primitive_lattice_vectors.u) ** 2))
-    v_magnitude = onp.sqrt(onp.sum(onp.abs(primitive_lattice_vectors.v) ** 2))
+    ku_spacing = onp.sqrt(onp.sum(onp.abs(reciprocal_vectors.u) ** 2))
+    kv_spacing = onp.sqrt(onp.sum(onp.abs(reciprocal_vectors.v) ** 2))
 
-    nu = onp.around(onp.sqrt(approximate_num_terms * v_magnitude / u_magnitude))
-    nv = onp.around(approximate_num_terms / nu)
+    # Solve for `(nu, nv)` such that we approximately satisfy
+    #     (2 * nu + 1) * (2 * nv + 1) = approximate_num_terms
+    # and
+    #     nu / nv = kv_spacing / ku_spacing
+    # Since `ku_spacing` and `kv_spacing` give the spacing of points in reciprocal
+    # space along the ku and kv directions, respectively, this second equation ensures
+    # that we are chosing points in a parallelogram with equal-length sides in k-space.
+    # (Note that while the sides of the parallelogram have equal length, the number of
+    # points along each direction will differ, as these are spaced by `ku_spacing` and
+    # `kv_spacing`.)
+    
+    def _solve_quadratic(ratio):
+        a = 4 * ratio
+        b = 2 * (ratio + 1)
+        c = 1 - approximate_num_terms
+        nu = (-b + onp.sqrt(b**2 - 4 * a * c)) / (2 * a)
+        return onp.around(nu)
+
+    nu = _solve_quadratic(ku_spacing / kv_spacing)
+    nv = _solve_quadratic(kv_spacing / ku_spacing)
 
     G1, G2 = onp.meshgrid(
-        onp.arange(-int(nu / 2), int(nu / 2) + 1),
-        onp.arange(-int(nv / 2), int(nv / 2) + 1),
+        onp.arange(-nu, nu + 1),
+        onp.arange(-nv, nv + 1),
         indexing="ij",
     )
     G1 = G1.flatten()
     G2 = G2.flatten()
     G = onp.stack([G1, G2], axis=-1)
-
     # Generate the actual vectors and compute their magnitude.
     vectors = (
-        G1[..., onp.newaxis] * primitive_lattice_vectors.u[..., onp.newaxis, :]
-        + G2[..., onp.newaxis] * primitive_lattice_vectors.v[..., onp.newaxis, :]
+        G1[..., onp.newaxis] * reciprocal_vectors.u[..., onp.newaxis, :]
+        + G2[..., onp.newaxis] * reciprocal_vectors.v[..., onp.newaxis, :]
     )
     magnitude = onp.linalg.norm(vectors, axis=-1)
 

--- a/fmmax/basis.py
+++ b/fmmax/basis.py
@@ -260,7 +260,7 @@ def transverse_wavevectors(
 
 
 def _basis_coefficients_circular(
-    reciprocal_vectors: LatticeVectors,
+    primitive_lattice_vectors: LatticeVectors,
     approximate_num_terms: int,
 ) -> onp.ndarray:
     """Computes the basis coefficients of lattice vectors lying within a circle.
@@ -271,7 +271,7 @@ def _basis_coefficients_circular(
     the set will generally be close to `approximate_num_terms`.
 
     Args:
-        reciprocal_vectors: The primitive vectors for the reciprocal-space lattice.
+        primitive_lattice_vectors: Primitive vectors for the reciprocal-space lattice.
         approximate_num_terms: The approximate number of terms in the expansion. To
             maintain a symmetric expansion, the total number of terms may differ from
             this value.
@@ -289,8 +289,8 @@ def _basis_coefficients_circular(
 
     # Generate the actual vectors and compute their magnitude.
     vectors = (
-        G1[..., onp.newaxis] * reciprocal_vectors.u[..., onp.newaxis, :]
-        + G2[..., onp.newaxis] * reciprocal_vectors.v[..., onp.newaxis, :]
+        G1[..., onp.newaxis] * primitive_lattice_vectors.u[..., onp.newaxis, :]
+        + G2[..., onp.newaxis] * primitive_lattice_vectors.v[..., onp.newaxis, :]
     )
     magnitude = onp.linalg.norm(vectors, axis=-1)
 
@@ -298,7 +298,9 @@ def _basis_coefficients_circular(
     # of `u` and `v` scaled by `num_terms`.
     max_magnitude = onp.sqrt(
         approximate_num_terms
-        * onp.abs(_cross_product(reciprocal_vectors.u, reciprocal_vectors.v))
+        * onp.abs(
+            _cross_product(primitive_lattice_vectors.u, primitive_lattice_vectors.v)
+        )
         / onp.pi
     )
     mask = magnitude < max_magnitude
@@ -313,7 +315,7 @@ def _basis_coefficients_circular(
 
 
 def _basis_coefficients_parallelogramic(
-    reciprocal_vectors: LatticeVectors,
+    primitive_lattice_vectors: LatticeVectors,
     approximate_num_terms: int,
 ) -> onp.ndarray:
     """Computes the basis coefficients of lattice vectors lying within a parallelogram.
@@ -323,7 +325,7 @@ def _basis_coefficients_parallelogramic(
     `approximate_num_terms`.
 
     Args:
-        reciprocal_vectors: The primitive vectors for the reciprocal-space lattice.
+        primitive_lattice_vectors: Primitive vectors for the reciprocal-space lattice.
         approximate_num_terms: The approximate number of terms in the expansion. To
             maintain a full parallelogram expansion, the total number of terms may
             differ from this value.
@@ -333,8 +335,8 @@ def _basis_coefficients_parallelogramic(
         coefficient for the first and second vector in the basis.
     """
 
-    ku_spacing = onp.sqrt(onp.sum(onp.abs(reciprocal_vectors.u) ** 2))
-    kv_spacing = onp.sqrt(onp.sum(onp.abs(reciprocal_vectors.v) ** 2))
+    ku_spacing = onp.sqrt(onp.sum(onp.abs(primitive_lattice_vectors.u) ** 2))
+    kv_spacing = onp.sqrt(onp.sum(onp.abs(primitive_lattice_vectors.v) ** 2))
 
     # Solve for `(nu, nv)` such that we approximately satisfy
     #     (2 * nu + 1) * (2 * nv + 1) = approximate_num_terms
@@ -367,8 +369,8 @@ def _basis_coefficients_parallelogramic(
     G = onp.stack([G1, G2], axis=-1)
     # Generate the actual vectors and compute their magnitude.
     vectors = (
-        G1[..., onp.newaxis] * reciprocal_vectors.u[..., onp.newaxis, :]
-        + G2[..., onp.newaxis] * reciprocal_vectors.v[..., onp.newaxis, :]
+        G1[..., onp.newaxis] * primitive_lattice_vectors.u[..., onp.newaxis, :]
+        + G2[..., onp.newaxis] * primitive_lattice_vectors.v[..., onp.newaxis, :]
     )
     magnitude = onp.linalg.norm(vectors, axis=-1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/examples/uled_test.py
+++ b/tests/examples/uled_test.py
@@ -32,7 +32,7 @@ class MicroLedTest(unittest.TestCase):
         with self.subTest("extraction efficiency"):
             onp.testing.assert_allclose(
                 extraction_efficiency,
-                [0.494347, 0.492305, 0.416735],
+                [0.661162, 0.687372, 0.310921],
                 atol=1e-3,
             )
 
@@ -41,9 +41,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(efields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [64.444786, 16.373577, 8.459116],
-                    [16.909363, 64.59829, 8.159439],
-                    [28.255959, 28.230724, 8.761396],
+                    [103.71359, 97.317444, 3.21536],
+                    [98.013145, 99.4448, 3.342574],
+                    [53.552944, 53.12181, 3.446113],
                 ],
                 rtol=1e-3,
             )
@@ -53,9 +53,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(hfields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [92.3925, 428.87042, 46.39356],
-                    [427.06384, 90.633675, 48.09156],
-                    [115.1582, 114.41496, 28.075932],
+                    [469.103, 561.54584, 21.604614],
+                    [586.9631, 470.38712, 20.628143],
+                    [351.44754, 341.26596, 9.459166],
                 ],
                 rtol=1e-3,
             )

--- a/tests/fmmax/basis_test.py
+++ b/tests/fmmax/basis_test.py
@@ -117,7 +117,7 @@ class ExpansionTest(unittest.TestCase):
         )
         expansion = basis.generate_expansion(
             primitive_lattice_vectors=primitive_lattice_vectors,
-            approximate_num_terms=20,
+            approximate_num_terms=25,
             truncation=basis.Truncation.PARALLELOGRAMIC,
         )
         onp.testing.assert_allclose(
@@ -225,3 +225,37 @@ class UnitCellCoordiantesTest(unittest.TestCase):
         onp.testing.assert_array_equal(
             y, jnp.broadcast_to(jnp.asarray(expected_y)[jnp.newaxis, :], y.shape)
         )
+
+
+class GenerateBasisTest(unittest.TestCase):
+    def test_parallelogramic_num_terms_is_monotonic(self):
+        approximate_num_terms = onp.arange(50, 250)
+        primitive_lattice_vectors = basis.LatticeVectors(
+            u=1.5 * basis.X,
+            v=0.75 * basis.Y,
+        )
+        num_terms = []
+        for n in approximate_num_terms:
+            coeffs = basis._basis_coefficients_parallelogramic(
+                primitive_lattice_vectors,
+                approximate_num_terms=n,
+            )
+            num_terms.append(coeffs.shape[0])
+        for n, n_next in zip(num_terms[:-1], num_terms[1:]):
+            self.assertGreaterEqual(n_next, n)
+
+    def test_circular_num_terms_is_monotonic(self):
+        approximate_num_terms = onp.arange(50, 250)
+        primitive_lattice_vectors = basis.LatticeVectors(
+            u=1.5 * basis.X,
+            v=0.75 * basis.Y,
+        )
+        num_terms = []
+        for n in approximate_num_terms:
+            coeffs = basis._basis_coefficients_circular(
+                primitive_lattice_vectors,
+                approximate_num_terms=n,
+            )
+            num_terms.append(coeffs.shape[0])
+        for n, n_next in zip(num_terms[:-1], num_terms[1:]):
+            self.assertGreaterEqual(n_next, n)


### PR DESCRIPTION
Currently, the parallelogramic basis option is poorly behaved, in the sense that as we increase the called-for `approximate_num_terms`, the actual number of terms in the expansion does not monotonically follow.

Here, we improve the logic for parallelogramic basis, and add tests which confirm the monotonic characteristic. These tests would have failed with the previous implementation. The same test is added also for the circular basis; this passes with the logic as-is.

The uLED regression test is updated, since the new basis logic results in a different expansion used during the test.