### PR TITLE
Updates to make CI pass with latest version of Jax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -8,9 +8,6 @@ on:
   schedule:
     - cron: "0 13 * * 1"  # Every Monday at 9AM EST
 
-defaults:
-  run:
-    shell: bash -l {0}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          mypy fmmax
-          mypy examples
+          find fmmax -name "*.py" | xargs mypy
+          find examples -name "*.py" | xargs mypy
         
       - name: Run Python tests
         run: |

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -37,7 +37,7 @@ jobs:
             darglint fmmax --strictness=short --ignore-raise=ValueError
             darglint examples --strictness=short --ignore-raise=ValueError
 
-  test:
+  test-fmmax:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -52,8 +52,24 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             pip install ".[tests,dev]"        
-      - name: Run Python tests
+      - name: Test fmmax
+        run: pytest tests/fmmax
+
+  test-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+      - name: Setup environment
         run: |
-            pytest tests/fmmax
-            python -m pytest tests/examples
+            python -m pip install --upgrade pip
+            pip install ".[tests,dev]"        
+      - name: Test examples
+        run: python -m pytest tests/examples
         

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -9,40 +9,51 @@ on:
     - cron: "0 13 * * 1"  # Every Monday at 9AM EST
 
 jobs:
-  test:
+  lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: pyproject.toml
-      
       - name: Setup environment
         run: |
             python -m pip install --upgrade pip
             pip install ".[tests,dev]"
-      
       - name: Lint Python files
         run: |
-          find . -name "*.py" | xargs black --check
-          find . -name "*.py" | xargs isort --profile black --check-only
-
-      - name: Validate docstrings
-        run: |
-          darglint fmmax --strictness=short --ignore-raise=ValueError
-          darglint examples --strictness=short --ignore-raise=ValueError
-
+            find . -name "*.py" | xargs black --check
+            find . -name "*.py" | xargs isort --profile black --check-only
       - name: Typecheck with mypy
         run: |
-          mypy fmmax
-          mypy examples
-        
+            mypy fmmax
+            mypy examples
+      - name: Validate docstrings
+        run: |
+            darglint fmmax --strictness=short --ignore-raise=ValueError
+            darglint examples --strictness=short --ignore-raise=ValueError
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+      - name: Setup environment
+        run: |
+            python -m pip install --upgrade pip
+            pip install ".[tests,dev]"        
       - name: Run Python tests
         run: |
-          pytest tests/fmmax
-          python -m pytest tests/examples
+            pytest tests/fmmax
+            python -m pytest tests/examples
+        

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          find fmmax -name "*.py" | xargs mypy
-          find examples -name "*.py" | xargs mypy
+          mypy fmmax
+          mypy examples
         
       - name: Run Python tests
         run: |

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 13 * * 1"  # Every Monday at 9AM EST
 
 defaults:
   run:
@@ -14,12 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
       
       - name: Setup environment
         run: |
@@ -38,8 +42,8 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          find fmmax -name "*.py" | xargs mypy
-          find examples -name "*.py" | xargs mypy
+          mypy fmmax
+          mypy examples
         
       - name: Run Python tests
         run: |

--- a/examples/crystal.py
+++ b/examples/crystal.py
@@ -530,11 +530,11 @@ def plot_dipole_fields(
     xplot, zplot = jnp.meshgrid(x, z, indexing="ij")
     field_plot = ex[:, :, 0].real
 
-    plt.figure(figsize=(jnp.amax(xplot), jnp.amax(zplot)), dpi=80)
+    plt.figure(figsize=(float(jnp.amax(xplot)), float(jnp.amax(zplot))), dpi=80)
     ax = plt.subplot(111)
     im = plt.pcolormesh(xplot, zplot, field_plot, shading="nearest", cmap="bwr")
 
-    im.set_clim((-jnp.amax(field_plot), jnp.amax(field_plot)))
+    im.set_clim((-float(jnp.amax(field_plot)), float(jnp.amax(field_plot))))
 
     contours = measure.find_contours(onp.array(section_xz))
     scale_factor = pitch / resolution
@@ -577,11 +577,11 @@ def plot_gaussian_fields(
     xplot, zplot = jnp.meshgrid(x, z, indexing="ij")
     field_plot = ex[wavelength_idx, :, :, 0].real
 
-    plt.figure(figsize=(jnp.amax(xplot), jnp.amax(zplot)), dpi=80)
+    plt.figure(figsize=(float(jnp.amax(xplot)), float(jnp.amax(zplot))), dpi=80)
     ax = plt.subplot(111)
     im = plt.pcolormesh(xplot, zplot, field_plot, shading="nearest", cmap="bwr")
 
-    im.set_clim((-jnp.amax(field_plot), jnp.amax(field_plot)))
+    im.set_clim((-float(jnp.amax(field_plot)), float(jnp.amax(field_plot))))
 
     contours = measure.find_contours(onp.array(section_xz))
     scale_factor = pitch / resolution

--- a/examples/metal_dipole.py
+++ b/examples/metal_dipole.py
@@ -204,11 +204,11 @@ def plot_metal_dipole_fields(
 
     xplot, zplot = jnp.meshgrid(x, z, indexing="ij")
 
-    plt.figure(figsize=(jnp.amax(xplot), jnp.amax(zplot)), dpi=80)
+    plt.figure(figsize=(float(jnp.amax(xplot)), float(jnp.amax(zplot))), dpi=80)
     ax = plt.subplot(111)
     im = ax.pcolormesh(xplot, zplot, field_plot, shading="nearest", cmap="magma")
 
-    clipval = jnp.percentile(field_plot, clip_percentile)
+    clipval = float(jnp.percentile(field_plot, clip_percentile))
     im.set_clim((0, clipval))
 
     ax.axis("equal")

--- a/examples/microlens_array.py
+++ b/examples/microlens_array.py
@@ -255,7 +255,7 @@ def plot_microlens_array_fields(**kwargs) -> None:
 
     xplot, zplot = jnp.meshgrid(x, z, indexing="ij")
 
-    plt.figure(figsize=(jnp.amax(xplot), jnp.amax(zplot)), dpi=80)
+    plt.figure(figsize=(float(jnp.amax(xplot)), float(jnp.amax(zplot))), dpi=80)
     ax = plt.subplot(111)
     ax.pcolormesh(xplot, zplot, field_plot, shading="nearest", cmap="viridis")
 

--- a/examples/sorter.py
+++ b/examples/sorter.py
@@ -12,7 +12,7 @@ import jax.numpy as jnp
 from fmmax import basis, fields, fmm, scattering, utils
 
 Aux = Dict[str, Any]
-Initializer = Callable[[jax.random.PRNGKeyArray, Tuple[int, int]], jnp.ndarray]
+Initializer = Callable[[jax.Array, Tuple[int, int]], jnp.ndarray]
 Params = Dict[str, Any]
 
 _DEFAULT_WAVELENGTH: jnp.ndarray = jnp.asarray([0.55])
@@ -127,7 +127,7 @@ class PolarizationSorterComponent:
         self._field_z_offset: jnp.ndarray = jnp.asarray(field_z_offset)
         self._density_initializer: Initializer = density_initializer
 
-    def init(self, key: jax.random.PRNGKeyArray) -> Params:
+    def init(self, key: jax.Array) -> Params:
         """Returns initial parameters for the polarization sorter."""
         return {
             "primitive_lattice_vectors": self._primitive_lattice_vectors,

--- a/examples/vector_fields.py
+++ b/examples/vector_fields.py
@@ -58,7 +58,7 @@ def _plot_vector_field(
 ) -> None:
     """Plots an overlay of `arr` with the vector field."""
     im = ax.imshow(arr, cmap="gray")
-    im.set_clim((-5 * (jnp.amax(arr) - jnp.amin(arr)), jnp.amax(arr)))
+    im.set_clim((-5 * float(jnp.amax(arr) - jnp.amin(arr)), float(jnp.amax(arr))))
 
     x, y = jnp.meshgrid(*[jnp.arange(d) for d in vx.shape], indexing="ij")
 

--- a/fmmax/fmm_matrices.py
+++ b/fmmax/fmm_matrices.py
@@ -41,10 +41,11 @@ def script_k_matrix_patterned(
     transverse_wavevectors: jnp.ndarray,
 ) -> jnp.ndarray:
     """Returns the patterned-layer script-k matrix from eq. 19 of [2012 Liu]."""
-    kx = transverse_wavevectors[..., 0].astype(z_permittivity_matrix.dtype)
-    ky = transverse_wavevectors[..., 1].astype(z_permittivity_matrix.dtype)
-    z_inv_kx = jnp.linalg.solve(z_permittivity_matrix, utils.diag(kx))
-    z_inv_ky = jnp.linalg.solve(z_permittivity_matrix, utils.diag(ky))
+    dtype = jnp.promote_types(z_permittivity_matrix, transverse_wavevectors)
+    kx = transverse_wavevectors[..., 0].astype(dtype)
+    ky = transverse_wavevectors[..., 1].astype(dtype)
+    z_inv_kx = jnp.linalg.solve(z_permittivity_matrix.astype(dtype), utils.diag(kx))
+    z_inv_ky = jnp.linalg.solve(z_permittivity_matrix.astype(dtype), utils.diag(ky))
     return jnp.block(
         [
             [ky[..., :, jnp.newaxis] * z_inv_ky, -ky[..., :, jnp.newaxis] * z_inv_kx],
@@ -58,10 +59,11 @@ def k_matrix_patterned(
     transverse_wavevectors: jnp.ndarray,
 ) -> jnp.ndarray:
     """Returns the k-matrix for patterned magnetic materials."""
-    kx = transverse_wavevectors[..., 0].astype(z_permeability_matrix.dtype)
-    ky = transverse_wavevectors[..., 1].astype(z_permeability_matrix.dtype)
-    z_inv_kx = jnp.linalg.solve(z_permeability_matrix, utils.diag(kx))
-    z_inv_ky = jnp.linalg.solve(z_permeability_matrix, utils.diag(ky))
+    dtype = jnp.promote_types(z_permeability_matrix, transverse_wavevectors)
+    kx = transverse_wavevectors[..., 0].astype(dtype)
+    ky = transverse_wavevectors[..., 1].astype(dtype)
+    z_inv_kx = jnp.linalg.solve(z_permeability_matrix.astype(dtype), utils.diag(kx))
+    z_inv_ky = jnp.linalg.solve(z_permeability_matrix.astype(dtype), utils.diag(ky))
     return jnp.block(
         [
             [kx[..., :, jnp.newaxis] * z_inv_kx, kx[..., :, jnp.newaxis] * z_inv_ky],

--- a/fmmax/fmm_matrices.py
+++ b/fmmax/fmm_matrices.py
@@ -41,8 +41,8 @@ def script_k_matrix_patterned(
     transverse_wavevectors: jnp.ndarray,
 ) -> jnp.ndarray:
     """Returns the patterned-layer script-k matrix from eq. 19 of [2012 Liu]."""
-    kx = transverse_wavevectors[..., 0]
-    ky = transverse_wavevectors[..., 1]
+    kx = transverse_wavevectors[..., 0].astype(z_permittivity_matrix.dtype)
+    ky = transverse_wavevectors[..., 1].astype(z_permittivity_matrix.dtype)
     z_inv_kx = jnp.linalg.solve(z_permittivity_matrix, utils.diag(kx))
     z_inv_ky = jnp.linalg.solve(z_permittivity_matrix, utils.diag(ky))
     return jnp.block(
@@ -58,8 +58,8 @@ def k_matrix_patterned(
     transverse_wavevectors: jnp.ndarray,
 ) -> jnp.ndarray:
     """Returns the k-matrix for patterned magnetic materials."""
-    kx = transverse_wavevectors[..., 0]
-    ky = transverse_wavevectors[..., 1]
+    kx = transverse_wavevectors[..., 0].astype(z_permeability_matrix.dtype)
+    ky = transverse_wavevectors[..., 1].astype(z_permeability_matrix.dtype)
     z_inv_kx = jnp.linalg.solve(z_permeability_matrix, utils.diag(kx))
     z_inv_ky = jnp.linalg.solve(z_permeability_matrix, utils.diag(ky))
     return jnp.block(

--- a/fmmax/sources.py
+++ b/fmmax/sources.py
@@ -58,10 +58,10 @@ def amplitudes_for_fields(
             f"`layer_solve_result` batch shape {layer_solve_result.batch_shape}."
         )
 
-    brillouin_grid_axes = utils.absolute_axes(brillouin_grid_axes, ex.ndim)
+    absolute_brillouin_grid_axes = utils.absolute_axes(brillouin_grid_axes, ex.ndim)
     brillouin_grid_shape = (
-        layer_solve_result.batch_shape[brillouin_grid_axes[0]],
-        layer_solve_result.batch_shape[brillouin_grid_axes[1]],
+        layer_solve_result.batch_shape[absolute_brillouin_grid_axes[0]],
+        layer_solve_result.batch_shape[absolute_brillouin_grid_axes[1]],
     )
 
     if (

--- a/fmmax/vector.py
+++ b/fmmax/vector.py
@@ -127,8 +127,9 @@ def compute_gradient(arr: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     batch_dims = arr.ndim - 2
     padding = tuple([(0, 0)] * batch_dims + [(1, 1), (1, 1)])
     arr_padded = jnp.pad(arr, padding, mode="wrap")
-    gradient_x = jnp.gradient(arr_padded, axis=-2)[..., 1:-1, 1:-1]
-    gradient_y = jnp.gradient(arr_padded, axis=-1)[..., 1:-1, 1:-1]
+    gradient_x, gradient_y = jnp.gradient(arr_padded, axis=(-2, -1))
+    gradient_x = gradient_x[..., 1:-1, 1:-1]
+    gradient_y = gradient_y[..., 1:-1, 1:-1]
     return gradient_x, gradient_y
 
 

--- a/tests/fmmax/fields_test.py
+++ b/tests/fmmax/fields_test.py
@@ -256,8 +256,8 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
                 x=x,
                 y=y,
             )
-            onp.testing.assert_allclose(efield, expected_efield, rtol=1e-4)
-            onp.testing.assert_allclose(hfield, expected_hfield, rtol=1e-4)
+            onp.testing.assert_allclose(efield, expected_efield, rtol=2e-4)
+            onp.testing.assert_allclose(hfield, expected_hfield, rtol=2e-4)
 
         with self.subTest("xy as flat arrays"):
             efield, hfield, _ = fields.layer_fields_3d_on_coordinates(
@@ -271,8 +271,8 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             )
             efield = onp.reshape(efield, onp.shape(expected_efield))
             hfield = onp.reshape(hfield, onp.shape(expected_efield))
-            onp.testing.assert_allclose(efield, expected_efield, rtol=1e-4)
-            onp.testing.assert_allclose(hfield, expected_hfield, rtol=1e-4)
+            onp.testing.assert_allclose(efield, expected_efield, rtol=2e-4)
+            onp.testing.assert_allclose(hfield, expected_hfield, rtol=2e-4)
 
     @parameterized.parameterized.expand([[()], [(3,)]])
     def test_stack_fields_on_coordinates_match_fields_on_grid(self, batch_shape):

--- a/tests/fmmax/sources_test.py
+++ b/tests/fmmax/sources_test.py
@@ -107,7 +107,7 @@ class FieldSourcesTest(unittest.TestCase):
             formulation=fmm.Formulation.FFT,
         )
         with self.assertRaisesRegex(
-            ValueError, "All fields must be rank 3 with matching shape"
+            ValueError, "All fields must have rank of at least 3"
         ):
             sources.amplitudes_for_fields(
                 ex=jnp.ones((20, 20, 1)),


### PR DESCRIPTION
CI has been failing for several reasons

- A new version of jax caused new mypy errors to show up, requiring e.g. explicit casting to float
- A new version of jax appears to be more strict about datatypes, complaining about operations using `complex64` and `complex128`. This is fixed by explicitly casting some types in a `jax.numpy.linalg.solve` to ensure that all operands share a common type.
- The batch-compatible `amplitudes_for_fields` was overly strict about shapes, requiring fields to have a batch dimension. This caused existing tests to fail. We update the shape validation and add more tests.
- A test in `fields` module failed due to tolerances.

Here, we fix all these errors, and also make some updates to the CI
- split CI into multiple jobs run in parallel, so that it completes more quickly
- Run CI on a schedule, to ensure that new errors are caught
- Simplify some commands, e.g. mypy invocation
- Add dependabot to keep the CI workflow updated
