### PR TITLE
Relax the basis shape assertion

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -53,7 +53,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install ".[tests,dev]"        
       - name: Test fmmax
-        run: pytest tests/fmmax
+        run: python -m pytest tests/fmmax
 
   test-examples:
     runs-on: ubuntu-latest

--- a/fmmax/basis.py
+++ b/fmmax/basis.py
@@ -36,9 +36,9 @@ class LatticeVectors:
 
     def __post_init__(self) -> None:
         if isinstance(self.u, jnp.ndarray):
-            if self.u.shape != (2,) or self.v.shape != (2,):
+            if self.u.shape[-1] != 2 or self.v.shape[-1] != 2:
                 raise ValueError(
-                    f"`u` and `v` must have length 2, but got shapes "
+                    f"`u` and `v` must have a trailing length of 2, but got shapes "
                     f"{self.u.shape} and {self.v.shape}."
                 )
 

--- a/tests/fmmax/grad_test.py
+++ b/tests/fmmax/grad_test.py
@@ -4,17 +4,17 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 """
 
 import unittest
+from typing import Any, Dict, Tuple
 
 import jax
 import numpy as onp
 import parameterized
+from jax import grad, jacrev
+from jax import numpy as jnp
+from jax import value_and_grad
 
 from examples import sorter
 from fmmax import basis, fmm
-from typing import Dict, Any, Tuple
-
-from jax import grad, value_and_grad, jacrev
-from jax import numpy as jnp
 
 Params = Dict[str, Any]
 Aux = Dict[str, Any]

--- a/tests/fmmax/grad_test.py
+++ b/tests/fmmax/grad_test.py
@@ -1,0 +1,40 @@
+"""Tests for various jax grad functions.
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+"""
+
+import unittest
+
+import jax
+import numpy as onp
+import parameterized
+
+from examples import sorter
+from fmmax import basis, fmm
+from typing import Dict, Any, Tuple
+
+from jax import grad, value_and_grad, jacrev
+from jax import numpy as jnp
+
+Params = Dict[str, Any]
+Aux = Dict[str, Any]
+
+
+class JaxGradTest(unittest.TestCase):
+    @parameterized.parameterized.expand([grad, value_and_grad, jacrev])
+    def test_jax_grad_functions(self, grad_func):
+        psc = sorter.PolarizationSorterComponent(approximate_num_terms=100)
+        params: Params = psc.init(jax.random.PRNGKey(0))
+        density = params["layers"]["sorter"]["density"]
+
+        def loss_fn(
+            params: Params,
+        ) -> Tuple[jnp.ndarray, Tuple[jnp.ndarray, Aux]]:
+            response, aux = psc.response(params)
+            loss = (
+                jnp.sum((jnp.zeros(response.shape) - response) ** 2) / response.shape[0]
+            )
+            return loss, (response, aux)
+
+        params["layers"]["sorter"]["density"] = density * 0 + 0.5
+        grad_func(loss_fn, has_aux=True)(params)


### PR DESCRIPTION
Fixes #47

Here we allow a `basis` `LatticeVector` shape to take on batch dimensions, which is important for different kinds of `grad` operations on FOMs that may have quite a bit of structure to them (e.g. pytrees). We add a test that fails on `main`, but passes with this relaxed assertion.