### PR TITLE
New vector field scheme

### DIFF
--- a/examples/vector_fields.py
+++ b/examples/vector_fields.py
@@ -22,15 +22,20 @@ def plot_vector_fields(
         indexing="ij",
     )
     arr = (x**2 + y**2 < 0.4**2).astype(float)
+    expansion = basis.generate_expansion(
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        approximate_num_terms=200,
+        truncation=basis.Truncation.CIRCULAR,
+    )
 
-    fig = plt.figure(figsize=(7, 3))
+    fig = plt.figure(figsize=(7, 4.5))
 
     for i, scheme_name in enumerate(vector.VECTOR_FIELD_SCHEMES):
         tx, ty = vector.VECTOR_FIELD_SCHEMES[scheme_name](
-            arr, primitive_lattice_vectors
+            arr, expansion, primitive_lattice_vectors
         )
 
-        ax = plt.subplot(1, 4, i + 1)
+        ax = plt.subplot(2, 4, i + 1)
         _plot_vector_field(
             ax, arr, tx, ty, scale=0.7, interval=interval, title=scheme_name
         )

--- a/fmmax/fft.py
+++ b/fmmax/fft.py
@@ -128,7 +128,7 @@ def _validate_shape_for_expansion(
     expansion: basis.Expansion,
 ) -> None:
     """Validates that the shape is sufficient for the provided expansion."""
-    min_shape = _min_array_shape_for_expansion(expansion)
+    min_shape = min_array_shape_for_expansion(expansion)
     if any([d < dmin for d, dmin in zip(shape[-2:], min_shape)]):
         raise ValueError(
             f"`shape` is insufficient for `expansion`, the minimum shape for the "
@@ -136,7 +136,7 @@ def _validate_shape_for_expansion(
         )
 
 
-def _min_array_shape_for_expansion(expansion: basis.Expansion) -> Tuple[int, int]:
+def min_array_shape_for_expansion(expansion: basis.Expansion) -> Tuple[int, int]:
     """Returns the minimum allowed shape for an array to be expanded."""
     return (
         int(2 * max(abs(expansion.basis_coefficients[:, 0])) + 1),

--- a/fmmax/fmm.py
+++ b/fmmax/fmm.py
@@ -28,6 +28,10 @@ class Formulation(enum.Enum):
     JONES: str = vector.JONES
     NORMAL: str = vector.NORMAL
     POL: str = vector.POL
+    JONES_DIRECT_FOURIER: str = vector.JONES_DIRECT_FOURIER
+    JONES_FOURIER: str = vector.JONES_FOURIER
+    NORMAL_FOURIER: str = vector.NORMAL_FOURIER
+    POL_FOURIER: str = vector.POL_FOURIER
 
 
 def eigensolve_isotropic_media(
@@ -797,7 +801,7 @@ def fourier_matrices_patterned_isotropic_media(
         )
     else:
         vector_fn = vector.VECTOR_FIELD_SCHEMES[formulation.value]
-        tx, ty = vector_fn(permittivity, primitive_lattice_vectors)
+        tx, ty = vector_fn(permittivity, expansion, primitive_lattice_vectors)
         _transverse_permittivity_fn = functools.partial(
             fmm_matrices.transverse_permittivity_vector,
             tx=tx,
@@ -876,7 +880,7 @@ def fourier_matrices_patterned_anisotropic_media(
         )
     else:
         vector_fn = vector.VECTOR_FIELD_SCHEMES[formulation.value]
-        tx, ty = vector_fn(vector_field_source, primitive_lattice_vectors)
+        tx, ty = vector_fn(vector_field_source, expansion, primitive_lattice_vectors)
         _transverse_permittivity_fn = functools.partial(
             fmm_matrices.transverse_permittivity_vector_anisotropic,
             tx=tx,

--- a/fmmax/vector_fourier.py
+++ b/fmmax/vector_fourier.py
@@ -1,0 +1,446 @@
+"""Functions related to tangent vector field generation.
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+"""
+
+import functools
+from typing import List, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from fmmax import basis, fft, utils
+
+
+def compute_field_jones_direct(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    fourier_loss_weight: float,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute tangent vector field using the Jones direct method."""
+    return compute_tangent_field(
+        arr=arr,
+        expansion=expansion,
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        use_jones_direct=True,
+        fourier_loss_weight=fourier_loss_weight,
+    )
+
+
+def compute_field_pol(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    fourier_loss_weight: float,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute tangent vector field using the Pol method."""
+    return compute_tangent_field(
+        arr=arr,
+        expansion=expansion,
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        use_jones_direct=False,
+        fourier_loss_weight=fourier_loss_weight,
+    )
+
+
+def compute_field_jones(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    fourier_loss_weight: float,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute tangent vector field using the Jones method."""
+    tx, ty = compute_tangent_field(
+        arr=arr,
+        expansion=expansion,
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        use_jones_direct=False,
+        fourier_loss_weight=fourier_loss_weight,
+    )
+    jxjy = normalize_jones(jnp.stack([tx, ty], axis=-1))
+    jx = jxjy[..., 0]
+    jy = jxjy[..., 1]
+    return jx, jy
+
+
+def compute_field_normal(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    fourier_loss_weight: float,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute tangent vector field using the Normal method."""
+    tx, ty = compute_tangent_field(
+        arr=arr,
+        expansion=expansion,
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        use_jones_direct=False,
+        fourier_loss_weight=fourier_loss_weight,
+    )
+    txty = normalize_elementwise(jnp.stack([tx, ty], axis=-1))
+    tx = txty[..., 0]
+    ty = txty[..., 1]
+    return tx, ty
+
+
+# -----------------------------------------------------------------------------
+# Underlying functions used to compute all variants of the tangent fields.
+# -----------------------------------------------------------------------------
+
+
+def compute_tangent_field(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    use_jones_direct: bool,
+    fourier_loss_weight: float,
+    steps: int = 1,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute the tangent vector field for `arr`.
+
+    The calculation finds the minimum of a quadratic loss function using a single
+    Newton iteration. Rather than optimizing the real-space tangent field, the
+    Fourier coefficients are directly optimized.
+
+    Args:
+        arr: The array for which the normal vector field is sought.
+        expansion: The Fourier expansion for which the field is to be optimized.
+        primitive_lattice_vectors: Define the unit cell coordinates.
+        use_jones_direct: Specifies whether the complex Jones field is to be sought.
+        fourier_loss_weight: Determines the weight of the loss term penalizing
+            Fourier terms corresponding to high frequencies.
+
+    Returns:
+        The normal field, `(tx, ty)`.
+    """
+    batch_shape = arr.shape[:-2]
+    arr = utils.atleast_nd(arr, n=3)
+    arr = arr.reshape((-1,) + arr.shape[-2:])
+
+    field_fn = jax.vmap(
+        functools.partial(
+            _compute_tangent_field_no_batch,
+            use_jones_direct=use_jones_direct,
+            fourier_loss_weight=fourier_loss_weight,
+            steps=steps,
+        ),
+        in_axes=(0, None, None),
+    )
+    field = field_fn(
+        arr,
+        expansion,
+        primitive_lattice_vectors,
+    )
+    field = field.reshape(batch_shape + field.shape[-3:])
+    tx = field[..., 0]
+    ty = field[..., 1]
+    return tx, ty
+
+
+def _compute_tangent_field_no_batch(
+    arr: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    use_jones_direct: bool,
+    fourier_loss_weight: float,
+    steps: int,
+) -> jnp.ndarray:
+    """Compute the tangent vector field for `arr` with no batch dimensions."""
+    assert primitive_lattice_vectors.u.shape == (2,)
+    assert arr.ndim == 2
+
+    grid_shape: Tuple[int, int] = arr.shape[-2:]  # type: ignore[assignment]
+    arr = _filter_and_adjust_resolution(arr, expansion)
+    grad = compute_gradient(arr, primitive_lattice_vectors)
+
+    # Normalize the gradient if its maximum magnitude exceeds unity.
+    grad_magnitude = _field_magnitude(grad)
+    norm = jnp.maximum(1.0, jnp.amax(grad_magnitude, axis=(-3, -2, -1), keepdims=True))
+    grad /= norm
+
+    elementwise_alignment_weight = _field_magnitude(grad)
+
+    target_field = jnp.stack([grad[..., 1], -grad[..., 0]], axis=-1)
+    target_field = normalize_elementwise(target_field)
+    if use_jones_direct:
+        target_field = normalize_jones(target_field)
+
+    initial_field = target_field
+
+    fourier_field = fft.fft(initial_field, expansion=expansion, axes=(-3, -2))
+    flat_fourier_field = fourier_field.flatten()
+
+    for _ in range(steps):
+        _, jac, hessian = field_loss_value_jac_and_hessian(
+            flat_fourier_field=flat_fourier_field,
+            expansion=expansion,
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            target_field=target_field,
+            elementwise_alignment_loss_weight=elementwise_alignment_weight,
+            fourier_loss_weight=fourier_loss_weight,
+        )
+        flat_fourier_field -= jnp.linalg.solve(hessian, jac.conj())
+
+    fourier_field = flat_fourier_field.reshape((expansion.num_terms, 2))
+    field = fft.ifft(fourier_field, expansion=expansion, shape=grid_shape, axis=-2)
+
+    # Manually set the field in cases where `arr` is constant.
+    grad_is_zero = jnp.all(jnp.isclose(grad, 0.0), axis=(-3, -2, -1), keepdims=True)
+    field = jnp.where(grad_is_zero, jnp.ones_like(field), field)
+    return normalize(field)
+
+
+# -------------------------------------------------------------------------------------
+# Normalization and transform functions.
+# -------------------------------------------------------------------------------------
+
+
+def normalize_jones(field: jnp.ndarray) -> jnp.ndarray:
+    """Generates a Jones vector field following the "Jones" method of [2012 Liu]."""
+    assert field.shape[-1] == 2
+    field = normalize(field)
+    magnitude = _field_magnitude(field)
+
+    magnitude_near_zero = jnp.isclose(magnitude, 0.0)
+    magnitude_safe = jnp.where(magnitude_near_zero, 1.0, magnitude)
+    tx_norm = jnp.where(
+        magnitude_near_zero,
+        1 / jnp.sqrt(2),
+        field[..., 0, jnp.newaxis] / magnitude_safe,
+    )
+    ty_norm = jnp.where(
+        magnitude_near_zero,
+        1 / jnp.sqrt(2),
+        field[..., 1, jnp.newaxis] / magnitude_safe,
+    )
+
+    phi = jnp.pi / 8 * (1 + jnp.cos(jnp.pi * magnitude))
+    theta = _angle(tx_norm + 1j * ty_norm)
+
+    jx = jnp.exp(1j * theta) * (tx_norm * jnp.cos(phi) - ty_norm * 1j * jnp.sin(phi))
+    jy = jnp.exp(1j * theta) * (ty_norm * jnp.cos(phi) + tx_norm * 1j * jnp.sin(phi))
+    return jnp.concatenate([jx, jy], axis=-1)
+
+
+def normalize_elementwise(field: jnp.ndarray) -> jnp.ndarray:
+    """Normalize the elements of `field` to have magnitude `1` everywhere."""
+    magnitude = _field_magnitude(field)
+    magnitude_safe = jnp.where(jnp.isclose(magnitude, 0), 1, magnitude)
+    return field / magnitude_safe
+
+
+def normalize(field: jnp.ndarray) -> jnp.ndarray:
+    """Normalize `field` so that it has maximum magnitude `1`."""
+    max_magnitude = _max_field_magnitude(field)
+    max_magnitude_safe = jnp.where(jnp.isclose(max_magnitude, 0), 1, max_magnitude)
+    return field / max_magnitude_safe
+
+
+def _field_magnitude(field: jnp.ndarray) -> jnp.ndarray:
+    """Return the magnitude of `field`"""
+    magnitude_squared = jnp.sum(jnp.abs(field) ** 2, axis=-1, keepdims=True)
+    is_zero = magnitude_squared == 0
+    magnitude_squared_safe = jnp.where(is_zero, 1.0, magnitude_squared)
+    return jnp.where(is_zero, 0.0, jnp.sqrt(magnitude_squared_safe))
+
+
+def _max_field_magnitude(field: jnp.ndarray) -> jnp.ndarray:
+    """Returns the magnitude of the largest component in `field`."""
+    return jnp.amax(_field_magnitude(field), axis=(-3, -2), keepdims=True)
+
+
+def _angle(x: jnp.ndarray) -> jnp.ndarray:
+    """Computes `angle(x)` with special logic for when `x` equals zero."""
+    # Avoid taking the angle of an array with any near-zero elements, to avoid
+    # `nan` in the gradients.
+    is_near_zero = jnp.isclose(x, 0.0)
+    x_safe = jnp.where(is_near_zero, (1.0 + 0.0j), x)
+    return jnp.angle(x_safe)
+
+
+def _filter_and_adjust_resolution(
+    x: jnp.ndarray,
+    expansion: basis.Expansion,
+) -> jnp.ndarray:
+    """Filter `x` and adjust its resolution for the given `expansion`."""
+    y = fft.fft(x, expansion=expansion)
+    min_shape = fft.min_array_shape_for_expansion(expansion)
+    doubled_min_shape = (2 * min_shape[0], 2 * min_shape[1])
+    return fft.ifft(y, expansion=expansion, shape=doubled_min_shape)
+
+
+# -------------------------------------------------------------------------------------
+# Loss function
+# -------------------------------------------------------------------------------------
+
+
+def field_loss_value_jac_and_hessian(
+    flat_fourier_field: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    target_field: jnp.ndarray,
+    elementwise_alignment_loss_weight: jnp.ndarray,
+    fourier_loss_weight: float,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Compute the value, Jacobian, and Hessian of the field loss."""
+    assert flat_fourier_field.ndim == 1
+
+    def fn(flat_fourier_field):
+        fourier_field = jnp.reshape(flat_fourier_field, (-1, 2))
+        value = _field_loss(
+            fourier_field=fourier_field,
+            expansion=expansion,
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            target_field=target_field,
+            elementwise_alignment_loss_weight=elementwise_alignment_loss_weight,
+            fourier_loss_weight=fourier_loss_weight,
+        )
+        return value, value
+
+    def jac_fn(flat_fourier_field):
+        jac, value = jax.jacrev(fn, has_aux=True)(flat_fourier_field)
+        return jac, (value, jac)
+
+    hessian, (value, jac) = jax.jacrev(jac_fn, has_aux=True, holomorphic=True)(
+        flat_fourier_field
+    )
+
+    return value, jac, hessian
+
+
+def _field_loss(
+    fourier_field: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+    target_field: jnp.ndarray,
+    elementwise_alignment_loss_weight: jnp.ndarray,
+    fourier_loss_weight: float,
+) -> jnp.ndarray:
+    """Compute loss that favors smooth"""
+    shape: Tuple[int, int] = target_field.shape[-3:-1]  # type: ignore[assignment]
+    field = fft.ifft(
+        y=fourier_field,
+        expansion=expansion,
+        shape=shape,
+        axis=-2,
+    )
+    alignment_loss = _alignment_loss(
+        field, target_field, elementwise_alignment_loss_weight
+    )
+
+    fourier_loss = _fourier_loss(fourier_field, expansion, primitive_lattice_vectors)
+    return alignment_loss + fourier_loss_weight * fourier_loss
+
+
+def _alignment_loss(
+    field: jnp.ndarray,
+    target_field: jnp.ndarray,
+    elementwise_alignment_loss_weight: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute loss that penalizes differences between `field` and `target_field`."""
+    assert elementwise_alignment_loss_weight.ndim == field.ndim
+    elementwise_loss = jnp.sum(
+        jnp.abs(field - target_field) ** 2, axis=-1, keepdims=True
+    )
+    return jnp.mean(elementwise_alignment_loss_weight * elementwise_loss)
+
+
+def _fourier_loss(
+    fourier_field: jnp.ndarray,
+    expansion: basis.Expansion,
+    primitive_lattice_vectors: basis.LatticeVectors,
+) -> jnp.ndarray:
+    """Compute loss that penalizes high frequency Fourier components.
+
+    The loss is scaled for the size of the unit cell, i.e. two unit cells with
+    identical `fourier_field` and scaled `primitive_lattice_vectors` will have
+    identical loss.
+
+    Args:
+        fourier_field: The Fourier field for which the loss is sought.
+        expansion: The Fourier expansion for the field.
+        primitive_lattice_vectors: Defines the unit cell coordinates.
+
+    Returns:
+        The scalar fourier loss value.
+    """
+    transverse_wavevectors = basis.transverse_wavevectors(
+        primitive_lattice_vectors=primitive_lattice_vectors,
+        expansion=expansion,
+        in_plane_wavevector=jnp.zeros((2,)),
+    )
+
+    basis_vectors = jnp.stack(
+        [primitive_lattice_vectors.u, primitive_lattice_vectors.v],
+        axis=-1,
+    )
+    area = jnp.abs(jnp.linalg.det(basis_vectors))
+
+    kt = jnp.linalg.norm(transverse_wavevectors, axis=-1) * jnp.sqrt(area)
+    return jnp.sum(jnp.abs(fourier_field) ** 2 * kt[..., jnp.newaxis] ** 2)
+
+
+# -------------------------------------------------------------------------------------
+# Gradient calculation and transformation.
+# -------------------------------------------------------------------------------------
+
+
+def compute_gradient(
+    arr: jnp.ndarray,
+    primitive_lattice_vectors: basis.LatticeVectors,
+) -> jnp.ndarray:
+    """Computes the gradient of `arr`.
+
+    The gradient is scaled for the size of the unit cell, i.e. two unit cells with
+    identical `arr` and scaled `primitive_lattice_vectors` will have identical
+    gradient.
+
+    Args:
+        arr: The array for which the gradient is sought.
+        primitive_lattice_vectors: Defines the unit cell coordinates.
+
+    Returns:
+        The gradient, with shape `arr.shape + (2,)`.
+    """
+    basis_vectors = jnp.stack(
+        [primitive_lattice_vectors.u, primitive_lattice_vectors.v],
+        axis=-1,
+    )
+
+    area = jnp.abs(jnp.linalg.det(basis_vectors))
+    basis_vectors /= jnp.sqrt(area)
+
+    batch_dims = arr.ndim - 2
+    pad_width = tuple([(0, 0)] * batch_dims + [(1, 1)] * 2)
+    arr_padded = jnp.pad(arr, pad_width, mode="wrap")
+
+    axes = tuple(range(-2, 0))
+    partial_grad: List[jnp.ndarray]
+    partial_grad = jnp.gradient(arr_padded, axis=axes)  # type: ignore[assignment]
+    partial_grad = [_unpad(g, pad_width) for g in partial_grad]
+    partial_grad = [g * arr.shape[ax] for g, ax in zip(partial_grad, axes)]
+    return _transform_gradient(jnp.stack(partial_grad, axis=-1), basis_vectors)
+
+
+def _transform_gradient(
+    partial_grad: jnp.ndarray,
+    basis_vectors: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute gradient from partial gradient with arbitrary basis vectors."""
+    # https://en.wikipedia.org/wiki/Gradient#General_coordinates
+    metric_tensor = _metric_tensor(basis_vectors)
+    inverse_metric_tensor = jnp.linalg.inv(metric_tensor)
+    result: jnp.ndarray = partial_grad @ inverse_metric_tensor @ basis_vectors.T
+    return result
+
+
+def _metric_tensor(basis_vectors: jnp.ndarray) -> jnp.ndarray:
+    """Compute the metric tensor for a non-Cartesian, non-orthogonal basis."""
+    return basis_vectors.T @ basis_vectors
+
+
+def _unpad(arr: jnp.ndarray, pad_width: Tuple[Tuple[int, int], ...]) -> jnp.ndarray:
+    """Undoes a pad operation."""
+    slices = [slice(lo, size - hi) for (lo, hi), size in zip(pad_width, arr.shape)]
+    return arr[tuple(slices)]

--- a/fmmax/vector_fourier.py
+++ b/fmmax/vector_fourier.py
@@ -1,7 +1,4 @@
-"""Functions related to tangent vector field generation.
-
-Copyright (c) Meta Platforms, Inc. and affiliates.
-"""
+"""Functions related to tangent vector field generation."""
 
 import functools
 from typing import List, Tuple
@@ -110,6 +107,8 @@ def compute_tangent_field(
         use_jones_direct: Specifies whether the complex Jones field is to be sought.
         fourier_loss_weight: Determines the weight of the loss term penalizing
             Fourier terms corresponding to high frequencies.
+        steps: The number of Newton iterations to carry out. Generally, the default
+            single iteration is sufficient to obtain converged fields.
 
     Returns:
         The normal field, `(tx, ty)`.

--- a/tests/fmmax/fft_test.py
+++ b/tests/fmmax/fft_test.py
@@ -105,7 +105,7 @@ class ShapeValidationTest(unittest.TestCase):
     )
     def test_min_shape(self, basis_coefficients, expected_min_shape):
         expansion = basis.Expansion(basis_coefficients=basis_coefficients)
-        min_shape = fft._min_array_shape_for_expansion(expansion)
+        min_shape = fft.min_array_shape_for_expansion(expansion)
         self.assertSequenceEqual(min_shape, expected_min_shape)
 
     def test_fourier_convolution_matrix(self):

--- a/tests/fmmax/fmm_anisotropic_test.py
+++ b/tests/fmmax/fmm_anisotropic_test.py
@@ -46,7 +46,7 @@ class AnisotropicMatchesIsotropicGratingTest(unittest.TestCase):
         primitive_lattice_vectors = basis.LatticeVectors(u=basis.X, v=basis.Y)
         expansion = basis.generate_expansion(
             primitive_lattice_vectors=primitive_lattice_vectors,
-            approximate_num_terms=200,
+            approximate_num_terms=220,
             truncation=basis.Truncation.CIRCULAR,
         )
         eigensolve_kwargs = {
@@ -118,6 +118,8 @@ class AnisotropicMatchesIsotropicGratingTest(unittest.TestCase):
             (fmm.Formulation.FFT, jnp.pi / 2),
             (fmm.Formulation.JONES_DIRECT, 0.0),
             (fmm.Formulation.JONES_DIRECT, jnp.pi / 2),
+            (fmm.Formulation.JONES_DIRECT_FOURIER, 0.0),
+            (fmm.Formulation.JONES_DIRECT_FOURIER, jnp.pi / 2),
         ]
     )
     def test_reflection_with_anisotropic_eignensolve_matches_isotropic_tight_tolerance(
@@ -136,6 +138,8 @@ class AnisotropicMatchesIsotropicGratingTest(unittest.TestCase):
         [
             (fmm.Formulation.JONES_DIRECT, jnp.pi / 3),
             (fmm.Formulation.JONES_DIRECT, 2 * jnp.pi / 3),
+            (fmm.Formulation.JONES_DIRECT_FOURIER, jnp.pi / 3),
+            (fmm.Formulation.JONES_DIRECT_FOURIER, 2 * jnp.pi / 3),
         ]
     )
     def test_reflection_with_anisotropic_eignensolve_matches_isotropic_loose_tolerance(
@@ -193,6 +197,18 @@ class AnisotropicMagneticFresnelReflectionTest(unittest.TestCase):
             [10.0, 1.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT],
             [1.0, 10.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT],
             [10.0, 10.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT],
+            # Patterned media, vector formulation.
+            [1.0, 1.0, 0.0, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [10.0, 1.0, 0.0, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [1.0, 10.0, 0.0, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [1.0, 1.0, jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [10.0, 1.0, jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [1.0, 10.0, jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [10.0, 10.0, jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [1.0, 1.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [10.0, 1.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [1.0, 10.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [10.0, 10.0, jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
         ]
     )
     def test_reflection_matches_expected(
@@ -292,6 +308,11 @@ class AnisotropicMagneticFresnelReflectionTest(unittest.TestCase):
             [jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT],
             [jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT],
             [jnp.pi / 2, (10, 10), fmm.Formulation.JONES_DIRECT],
+            [0.0, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 5, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 2, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
         ]
     )
     def test_reflection_anisotropic_permittivity_matches_expected(
@@ -404,6 +425,11 @@ class AnisotropicMagneticFresnelReflectionTest(unittest.TestCase):
             [jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT],
             [jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT],
             [jnp.pi / 2, (10, 10), fmm.Formulation.JONES_DIRECT],
+            [0.0, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 5, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 4, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 3, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
+            [jnp.pi / 2, (10, 10), fmm.Formulation.JONES_DIRECT_FOURIER],
         ]
     )
     def test_reflection_anisotropic_permeability_matches_expected(

--- a/tests/fmmax/fmm_test.py
+++ b/tests/fmmax/fmm_test.py
@@ -145,13 +145,7 @@ class GrcwaEigensolveComparisonTest(unittest.TestCase):
 
 class LayerEigensolveTest(unittest.TestCase):
     @parameterized.parameterized.expand(
-        [
-            (fmm.Formulation.FFT,),
-            (fmm.Formulation.POL,),
-            (fmm.Formulation.NORMAL,),
-            (fmm.Formulation.JONES,),
-            (fmm.Formulation.JONES_DIRECT,),
-        ]
+        [(formulation,) for formulation in fmm.Formulation]
     )
     def test_uniform_matches_patterned(self, formulation):
         permittivity = jnp.asarray([[3.14]])
@@ -230,13 +224,7 @@ class LayerEigensolveTest(unittest.TestCase):
                     )
 
     @parameterized.parameterized.expand(
-        [
-            (fmm.Formulation.FFT,),
-            (fmm.Formulation.POL,),
-            (fmm.Formulation.NORMAL,),
-            (fmm.Formulation.JONES,),
-            (fmm.Formulation.JONES_DIRECT,),
-        ]
+        [(formulation,) for formulation in fmm.Formulation]
     )
     def test_patterned_layer_batch_matches_single(self, formulation):
         wavelength = jnp.asarray([[[0.2]], [[0.3]], [[0.4]]])

--- a/tests/fmmax/validation_test.py
+++ b/tests/fmmax/validation_test.py
@@ -8,7 +8,7 @@ import unittest
 import jax
 import jax.numpy as jnp
 import numpy as onp
-import parameterized
+from parameterized import parameterized
 
 from fmmax import basis, fields, fmm, scattering
 
@@ -60,7 +60,7 @@ def _solve_fresnel_reflection(n1, n2, theta_i):
 
 
 class ThinFilmComparisonTest(unittest.TestCase):
-    @parameterized.parameterized.expand([((1, 1),), ((64, 64),)])
+    @parameterized.expand([((1, 1),), ((64, 64),)])
     def test_normal_incidence_matches_fresnel(self, permittivity_shape):
         n1 = 1.2
         n2 = 3.8
@@ -185,7 +185,13 @@ class ThinFilmComparisonTest(unittest.TestCase):
 
 
 class RotatedGratingTest(unittest.TestCase):
-    def test_different_unit_cells_give_same_reflection(self):
+    @parameterized.expand(
+        [
+            [fmm.Formulation.JONES_DIRECT],
+            [fmm.Formulation.JONES_DIRECT_FOURIER],
+        ]
+    )
+    def test_different_unit_cells_give_same_reflection(self, formulation):
         # Tests that different, nominally equivalent unit cell selections
         # actually yield equal reflectivity for a complex, wavy grating
         # structure.
@@ -242,7 +248,7 @@ class RotatedGratingTest(unittest.TestCase):
                 expansion=expansion,
                 permittivities=permittivities,
                 thicknesses=thicknesses,
-                formulation=fmm.Formulation.JONES_DIRECT,
+                formulation=formulation,
             )
             rte = s_matrix.s21[0, 0]
             rtm = s_matrix.s21[expansion.num_terms, expansion.num_terms]

--- a/tests/fmmax/vector_fourier_test.py
+++ b/tests/fmmax/vector_fourier_test.py
@@ -1,0 +1,358 @@
+"""Tests for `fmmax.vector_fourier`.
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+"""
+
+import functools
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as onp
+import pytest
+from parameterized import parameterized
+from scipy import ndimage
+
+from fmmax import basis, vector_fourier
+
+
+class TangentVectorTest(unittest.TestCase):
+    def _compute_field(
+        self,
+        approximate_num_terms,
+        scale,
+        shape,
+        arr_scale,
+        binarize_arr,
+        use_jones_direct,
+    ):
+        primitive_lattice_vectors = basis.LatticeVectors(
+            basis.X * scale, basis.Y * scale
+        )
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            approximate_num_terms=approximate_num_terms,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+        x, y = jnp.meshgrid(
+            jnp.linspace(0, scale, shape[0]),
+            jnp.linspace(0, scale, shape[1]),
+            indexing="ij",
+        )
+        distance = jnp.sqrt((x - scale / 2) ** 2 + (y - scale / 2) ** 2)
+        arr = jnp.exp(-(distance**2) / scale**2 * 30)
+        if binarize_arr:
+            arr = (arr > 0.5).astype(float)
+        arr *= arr_scale
+
+        return vector_fourier.compute_tangent_field(
+            arr,
+            expansion,
+            primitive_lattice_vectors,
+            use_jones_direct,
+            fourier_loss_weight=0.001,
+        )
+
+    @parameterized.expand(
+        [
+            # Cases with grayscale density and `use_jones_direct = False`.
+            (1, (160, 120), 1, False, False),  # Resolution invariance.
+            (1000, (80, 80), 1, False, False),  # Scale invariance.
+            (1, (80, 80), (1 + 0j), False, False),  # Phase invariance.
+            (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), False, False),
+            (1, (80, 80), (0 + 1j), False, False),
+            # Cases with binarized density and `use_jones_direct = False`.
+            (1, (160, 120), 1, True, False),  # Resolution invariance.
+            (1000, (80, 80), 1, True, False),  # Scale invariance.
+            (1, (80, 80), (1 + 0j), True, False),  # Phase invariance.
+            (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), True, False),
+            (1, (80, 80), (0 + 1j), True, False),
+            # Cases with `use_jones_direct = True`.
+            (1, (160, 120), 1, False, True),  # Grayscale, resolution invariance.
+            (1000, (80, 80), 1, False, True),  # Grayscale, scale invariance.
+            (1, (160, 120), 1, True, True),  # Binarized, resolution invariance.
+            (1000, (80, 80), 1, True, True),  # Binarized, scale invariance.
+        ]
+    )
+    def test_invariances(self, scale, shape, arr_scale, binarize_arr, use_jones_direct):
+        reference_tx, reference_ty = self._compute_field(
+            approximate_num_terms=200,
+            scale=1,
+            shape=(80, 80),
+            arr_scale=1,
+            binarize_arr=binarize_arr,
+            use_jones_direct=use_jones_direct,
+        )
+        zoom = (shape[0] / 80, shape[1] / 80)
+        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
+        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * arr_scale
+
+        tx, ty = self._compute_field(
+            approximate_num_terms=200,
+            scale=scale,
+            shape=shape,
+            arr_scale=arr_scale,
+            binarize_arr=binarize_arr,
+            use_jones_direct=use_jones_direct,
+        )
+        onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
+        onp.testing.assert_allclose(ty, expected_ty, atol=0.05)
+
+    @parameterized.expand([[True], [False]])
+    def test_batch_calculation_matches_single(self, use_jones_direct):
+        primitive_lattice_vectors = basis.LatticeVectors(basis.X, basis.Y)
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            approximate_num_terms=200,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+        x, y = jnp.meshgrid(
+            jnp.linspace(0, 1, 80), jnp.linspace(0, 1, 80), indexing="ij"
+        )
+        distance = jnp.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2)
+        arr = jnp.exp(
+            -(distance**2) * jnp.arange(10, 40, 5)[:, jnp.newaxis, jnp.newaxis]
+        )
+        assert arr.shape == (6, 80, 80)
+
+        tx_batch, ty_batch = vector_fourier.compute_tangent_field(
+            arr,
+            expansion,
+            primitive_lattice_vectors,
+            use_jones_direct=use_jones_direct,
+            fourier_loss_weight=0.01,
+        )
+
+        for i in range(arr.shape[0]):
+            tx, ty = vector_fourier.compute_tangent_field(
+                arr[i, :, :],
+                expansion,
+                primitive_lattice_vectors,
+                use_jones_direct=use_jones_direct,
+                fourier_loss_weight=0.01,
+            )
+            onp.testing.assert_allclose(tx, tx_batch[i, :, :], rtol=1e-5)
+            onp.testing.assert_allclose(ty, ty_batch[i, :, :], rtol=1e-5)
+
+    @parameterized.expand([[True], [False]])
+    def test_gradient_no_nan(self, use_jones_direct):
+        primitive_lattice_vectors = basis.LatticeVectors(basis.X, basis.Y)
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            approximate_num_terms=200,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+
+        def loss_fn(arr):
+            tx, ty = vector_fourier.compute_tangent_field(
+                arr=arr,
+                expansion=expansion,
+                primitive_lattice_vectors=primitive_lattice_vectors,
+                use_jones_direct=use_jones_direct,
+                fourier_loss_weight=0.01,
+            )
+            return jnp.sum(jnp.abs(tx) ** 2) + jnp.sum(jnp.abs(ty) ** 2)
+
+        x, y = jnp.meshgrid(
+            jnp.linspace(0, 1, 80), jnp.linspace(0, 1, 80), indexing="ij"
+        )
+        distance = jnp.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2)
+        arr = jnp.exp(
+            -(distance**2) * jnp.arange(10, 40, 5)[:, jnp.newaxis, jnp.newaxis]
+        )
+        grad = jax.grad(loss_fn)(arr)
+        self.assertFalse(jnp.any(jnp.isnan(grad)))
+
+    @parameterized.expand([[True], [False]])
+    def test_valid_result_with_uniform_array(self, use_jones_direct):
+        primitive_lattice_vectors = basis.LatticeVectors(basis.X, basis.Y)
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            approximate_num_terms=200,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+
+        def loss_fn(arr):
+            tx, ty = vector_fourier.compute_tangent_field(
+                arr=arr,
+                expansion=expansion,
+                primitive_lattice_vectors=primitive_lattice_vectors,
+                use_jones_direct=use_jones_direct,
+                fourier_loss_weight=0.01,
+            )
+            return jnp.sum(jnp.abs(tx) ** 2) + jnp.sum(jnp.abs(ty) ** 2), (tx, ty)
+
+        arr = jnp.zeros((80, 80))
+        (_, (tx, ty)), grad = jax.value_and_grad(loss_fn, has_aux=True)(arr)
+        self.assertFalse(jnp.any(jnp.isnan(tx)))
+        self.assertFalse(jnp.any(jnp.isnan(ty)))
+        self.assertFalse(jnp.any(jnp.isnan(grad)))
+
+    # def test_field_converges(self):
+    #     pass
+
+
+class NormalizeTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                vector_fourier.normalize_elementwise,
+                [[1 / jnp.sqrt(2), 1.0, 0.0, 1.0, 0.0]],
+                [[1 / jnp.sqrt(2), 0.0, 1.0, 0.0, 0.0]],
+            ),
+            (
+                vector_fourier.normalize,
+                [[1 / jnp.sqrt(2), 0.2 / jnp.sqrt(2), 0.0, 0.01 / jnp.sqrt(2), 0.0]],
+                [[1 / jnp.sqrt(2), 0.0, 0.2 / jnp.sqrt(2), 0.0, 0.0]],
+            ),
+            (
+                vector_fourier.normalize_jones,
+                [[0.5 + 0.5j, 0.734, 0.680, 0.707, 0.707]],
+                [[0.5 + 0.5j, 0.680j, 0.734j, 0.707j, 0.707j]],
+            ),
+        ]
+    )
+    def test_normalized_matches_expected(self, normalize_fn, expected_tx, expected_ty):
+        tx = jnp.asarray([[1.0, 0.2, 0.0, 0.01, 0.0]], dtype=float)
+        ty = jnp.asarray([[1.0, 0.0, 0.2, 0.0, 0.0]], dtype=float)
+        txty = normalize_fn(jnp.stack([tx, ty], axis=-1))
+        tx, ty = txty[..., 0], txty[..., 1]
+        onp.testing.assert_allclose(tx, jnp.asarray(expected_tx), rtol=1e-3)
+        onp.testing.assert_allclose(ty, jnp.asarray(expected_ty), rtol=1e-3)
+
+    @parameterized.expand(
+        [
+            (vector_fourier.normalize_elementwise,),
+            (vector_fourier.normalize,),
+            (vector_fourier.normalize_jones,),
+        ]
+    )
+    def test_zeros_no_nan(self, normalize_fn):
+        tx = jnp.zeros((20, 20))
+        ty = jnp.zeros((20, 20))
+        txty = normalize_fn(jnp.stack([tx, ty], axis=-1))
+        tx, ty = txty[..., 0], txty[..., 1]
+        self.assertFalse(onp.any(onp.isnan(tx)))
+        self.assertFalse(onp.any(onp.isnan(ty)))
+
+    @parameterized.expand(
+        [
+            (vector_fourier.normalize_elementwise,),
+            (vector_fourier.normalize,),
+            (vector_fourier.normalize_jones,),
+        ]
+    )
+    def test_gradient_no_nan(self, normalize_fn):
+        def loss_fn(tx, ty):
+            txty = normalize_fn(jnp.stack([tx, ty], axis=-1))
+            tx, ty = txty[..., 0], txty[..., 1]
+            return jnp.real(jnp.sum(tx) + jnp.sum(ty))
+
+        gx, gy = jax.grad(loss_fn, argnums=(0, 1))(jnp.zeros((5, 5)), jnp.zeros((5, 5)))
+        self.assertFalse(onp.any(onp.isnan(gx)))
+        self.assertFalse(onp.any(onp.isnan(gy)))
+
+
+class MagnitudeTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (0, 1, 1),
+            (1, 0, 1),
+            (1, 1, jnp.sqrt(2)),
+        ]
+    )
+    def test_magnitude(self, tx, ty, expected):
+        result = vector_fourier._field_magnitude(jnp.stack([tx, ty], axis=-1))
+        onp.testing.assert_allclose(result, expected)
+
+    def test_magnitude_gradient_no_nan(self):
+        grad = jax.grad(lambda x: jnp.squeeze(vector_fourier._field_magnitude(x)))(
+            jnp.zeros((2,))
+        )
+        self.assertFalse(onp.any(onp.isnan(grad)))
+
+
+class AngleTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (0, 1, jnp.pi / 2),
+            (1, 0, 0),
+            (1, 1, jnp.pi / 4),
+        ]
+    )
+    def test_angle(self, tx, ty, expected):
+        result = vector_fourier._angle(tx + 1j * ty)
+        onp.testing.assert_allclose(result, expected)
+
+    def test_angle_gradient_no_nan(self):
+        grad = jax.grad(vector_fourier._angle)(0.0)
+        self.assertFalse(onp.any(onp.isnan(grad)))
+
+
+class GradientTest(unittest.TestCase):
+    pass
+
+
+class TestNewtonIteration(unittest.TestCase):
+    pass
+
+
+# class LossTest(unittest.TestCase):
+#     @parameterized.parameterized.expand(
+#         [
+#             (1.0, 0.0, 1.0, 0.0, -1.0),
+#             (-1.0, 0.0, 1.0, 0.0, -1.0),
+#             (0.0, 1.0, 1.0, 0.0, 0.0),
+#         ]
+#     )
+#     def test_self_alignment_loss(self, tx, ty, tx0, ty0, expected):
+#         tx = jnp.asarray(tx)[jnp.newaxis, jnp.newaxis]
+#         ty = jnp.asarray(ty)[jnp.newaxis, jnp.newaxis]
+#         tx0 = jnp.asarray(tx0)[jnp.newaxis, jnp.newaxis]
+#         ty0 = jnp.asarray(ty0)[jnp.newaxis, jnp.newaxis]
+#         loss = vector_fourier._self_alignment_loss(tx, ty, tx0, ty0)
+#         onp.testing.assert_allclose(loss, expected)
+
+#     @parameterized.parameterized.expand(
+#         [
+#             (
+#                 jnp.ones((2, 2)),
+#                 jnp.zeros((2, 2)),
+#                 jnp.ones((2, 2)),
+#                 jnp.zeros((2, 2)),
+#                 -400,
+#             ),
+#             (
+#                 jnp.asarray([[1, 1], [-1, -1], [-1, -1], [1, 1]]),
+#                 jnp.zeros((4, 2)),
+#                 jnp.ones((4, 2)),
+#                 jnp.zeros((4, 2)),
+#                 -768.0,
+#             ),
+#         ]
+#     )
+#     def test_field_loss(self, tx, ty, tx0, ty0, expected):
+#         loss = vector_fourier._field_loss(
+#             tx, ty, tx0, ty0, alignment_weight=100, smoothness_weight=2
+#         )
+#         onp.testing.assert_allclose(loss, expected)
+
+#     def test_field_loss_batch_matches_single(self):
+#         key = jax.random.PRNGKey(0)
+#         tx, ty, tx0, ty0 = jax.random.uniform(key, (4, 8, 5, 10))
+#         loss = vector_fourier._field_loss(
+#             tx, ty, tx0, ty0, alignment_weight=100, smoothness_weight=2
+#         )
+#         expected_loss = 0
+#         for tx_slice, ty_slice, tx0_slice, ty0_slice in zip(tx, ty, tx0, ty0):
+#             expected_loss += vector_fourier._field_loss(
+#                 tx_slice,
+#                 ty_slice,
+#                 tx0_slice,
+#                 ty0_slice,
+#                 alignment_weight=100,
+#                 smoothness_weight=2,
+#             )
+#         onp.testing.assert_allclose(loss, expected_loss, rtol=1e-6)


### PR DESCRIPTION
Introduce new vector field generating schemes, which are similar to existing but suffixed with "_FOURIER". These are faster while offering similar vector fields. It addresses #28, and the new schemes give proper vector fields for odd-shaped unit cells (see issue #55).

Speed comparison:
```
shape = (45, 120), approximate_num_terms = 200
  Fourier scheme:  25.3 ms ± 1.68 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
  existing scheme: 908 ms ± 2.68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
shape = (45, 120), approximate_num_terms = 400
  Fourier scheme:  63.6 ms ± 3.16 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
  existing scheme: 907 ms ± 1.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
shape = (140, 140), approximate_num_terms = 800
  Fourier scheme:  334 ms ± 11.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  existing scheme: 3.86 s ± 1.75 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
shape = (140, 140), approximate_num_terms = 2000
  Fourier scheme:  1.28 s ± 55.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
  existing scheme: 3.87 s ± 22.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

uLED example convergence of extraction efficiency
![image](https://github.com/facebookresearch/fmmax/assets/30735893/516d455f-9638-4a0f-9b0b-214d1bbbe730)

Vector field image produced by vector_fields.py example
![vector_fields](https://github.com/facebookresearch/fmmax/assets/30735893/2e788a49-c1d6-4282-ab68-879867d0dd11)

In the future we should consider removing the original schemes.
