### PR TITLE
Add smoothness loss to new Fourier-based vector schemes

### DIFF
--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -487,7 +487,6 @@ POL_FOURIER: str = "pol_fourier"
 FOURIER_LOSS_WEIGHT: float = 0.01
 FOURIER_LOSS_WEIGHT_JONES_DIRECT: float = 0.0001
 
-
 VECTOR_FIELD_SCHEMES: Dict[str, VectorFn] = {
     JONES_DIRECT: functools.partial(
         normalized_vector_field,
@@ -554,17 +553,21 @@ VECTOR_FIELD_SCHEMES: Dict[str, VectorFn] = {
     JONES_DIRECT_FOURIER: functools.partial(
         vector_fourier.compute_field_jones_direct,
         fourier_loss_weight=FOURIER_LOSS_WEIGHT_JONES_DIRECT,
+        smoothness_loss_weight=0.0,
     ),
     JONES_FOURIER: functools.partial(
         vector_fourier.compute_field_jones,
         fourier_loss_weight=FOURIER_LOSS_WEIGHT,
+        smoothness_loss_weight=0.0,
     ),
     NORMAL_FOURIER: functools.partial(
         vector_fourier.compute_field_normal,
         fourier_loss_weight=FOURIER_LOSS_WEIGHT,
+        smoothness_loss_weight=0.0,
     ),
     POL_FOURIER: functools.partial(
         vector_fourier.compute_field_pol,
         fourier_loss_weight=FOURIER_LOSS_WEIGHT,
+        smoothness_loss_weight=0.0,
     ),
 }

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -115,9 +115,9 @@ def compute_tangent_field(
         primitive_lattice_vectors: Define the unit cell coordinates.
         use_jones_direct: Specifies whether the complex Jones field is to be sought.
         fourier_loss_weight: Determines the weight of the loss term penalizing
-            Fourier terms corresponding to high frequencies.
+            Fourier terms corresponding to high frequencies. Should be positive.
         smoothness_loss_weight: Determines the weight of the loss term rewarding
-            smoothness of the tangent field in real space.
+            smoothness of the tangent field in real space. Should be positive.
         steps: The number of Newton iterations to carry out. Generally, the default
             single iteration is sufficient to obtain converged fields.
 

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -14,6 +14,7 @@ def compute_field_jones_direct(
     expansion: basis.Expansion,
     primitive_lattice_vectors: basis.LatticeVectors,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute tangent vector field using the Jones direct method."""
     return compute_tangent_field(
@@ -22,6 +23,7 @@ def compute_field_jones_direct(
         primitive_lattice_vectors=primitive_lattice_vectors,
         use_jones_direct=True,
         fourier_loss_weight=fourier_loss_weight,
+        smoothness_loss_weight=smoothness_loss_weight,
     )
 
 
@@ -30,6 +32,7 @@ def compute_field_pol(
     expansion: basis.Expansion,
     primitive_lattice_vectors: basis.LatticeVectors,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute tangent vector field using the Pol method."""
     return compute_tangent_field(
@@ -38,6 +41,7 @@ def compute_field_pol(
         primitive_lattice_vectors=primitive_lattice_vectors,
         use_jones_direct=False,
         fourier_loss_weight=fourier_loss_weight,
+        smoothness_loss_weight=smoothness_loss_weight,
     )
 
 
@@ -46,6 +50,7 @@ def compute_field_jones(
     expansion: basis.Expansion,
     primitive_lattice_vectors: basis.LatticeVectors,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute tangent vector field using the Jones method."""
     tx, ty = compute_tangent_field(
@@ -54,6 +59,7 @@ def compute_field_jones(
         primitive_lattice_vectors=primitive_lattice_vectors,
         use_jones_direct=False,
         fourier_loss_weight=fourier_loss_weight,
+        smoothness_loss_weight=smoothness_loss_weight,
     )
     jxjy = normalize_jones(jnp.stack([tx, ty], axis=-1))
     jx = jxjy[..., 0]
@@ -66,6 +72,7 @@ def compute_field_normal(
     expansion: basis.Expansion,
     primitive_lattice_vectors: basis.LatticeVectors,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute tangent vector field using the Normal method."""
     tx, ty = compute_tangent_field(
@@ -74,6 +81,7 @@ def compute_field_normal(
         primitive_lattice_vectors=primitive_lattice_vectors,
         use_jones_direct=False,
         fourier_loss_weight=fourier_loss_weight,
+        smoothness_loss_weight=smoothness_loss_weight,
     )
     txty = normalize_elementwise(jnp.stack([tx, ty], axis=-1))
     tx = txty[..., 0]
@@ -92,6 +100,7 @@ def compute_tangent_field(
     primitive_lattice_vectors: basis.LatticeVectors,
     use_jones_direct: bool,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
     steps: int = 1,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Compute the tangent vector field for `arr`.
@@ -107,6 +116,8 @@ def compute_tangent_field(
         use_jones_direct: Specifies whether the complex Jones field is to be sought.
         fourier_loss_weight: Determines the weight of the loss term penalizing
             Fourier terms corresponding to high frequencies.
+        smoothness_loss_weight: Determines the weight of the loss term rewarding
+            smoothness of the tangent field in real space.
         steps: The number of Newton iterations to carry out. Generally, the default
             single iteration is sufficient to obtain converged fields.
 
@@ -122,6 +133,7 @@ def compute_tangent_field(
             _compute_tangent_field_no_batch,
             use_jones_direct=use_jones_direct,
             fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
             steps=steps,
         ),
         in_axes=(0, None, None),
@@ -143,6 +155,7 @@ def _compute_tangent_field_no_batch(
     primitive_lattice_vectors: basis.LatticeVectors,
     use_jones_direct: bool,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
     steps: int,
 ) -> jnp.ndarray:
     """Compute the tangent vector field for `arr` with no batch dimensions."""
@@ -164,8 +177,9 @@ def _compute_tangent_field_no_batch(
     target_field = normalize_elementwise(target_field)
     if use_jones_direct:
         target_field = normalize_jones(target_field)
-
-    initial_field = target_field
+        initial_field = target_field
+    else:
+        initial_field = normalize(jnp.stack([grad[..., 1], -grad[..., 0]], axis=-1))
 
     fourier_field = fft.fft(initial_field, expansion=expansion, axes=(-3, -2))
     flat_fourier_field = fourier_field.flatten()
@@ -178,6 +192,7 @@ def _compute_tangent_field_no_batch(
             target_field=target_field,
             elementwise_alignment_loss_weight=elementwise_alignment_weight,
             fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
         )
         flat_fourier_field -= jnp.linalg.solve(hessian, jac.conj())
 
@@ -281,6 +296,7 @@ def field_loss_value_jac_and_hessian(
     target_field: jnp.ndarray,
     elementwise_alignment_loss_weight: jnp.ndarray,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Compute the value, Jacobian, and Hessian of the field loss."""
     assert flat_fourier_field.ndim == 1
@@ -294,6 +310,7 @@ def field_loss_value_jac_and_hessian(
             target_field=target_field,
             elementwise_alignment_loss_weight=elementwise_alignment_loss_weight,
             fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
         )
         return value, value
 
@@ -315,6 +332,7 @@ def _field_loss(
     target_field: jnp.ndarray,
     elementwise_alignment_loss_weight: jnp.ndarray,
     fourier_loss_weight: float,
+    smoothness_loss_weight: float,
 ) -> jnp.ndarray:
     """Compute loss that favors smooth"""
     shape: Tuple[int, int] = target_field.shape[-3:-1]  # type: ignore[assignment]
@@ -329,7 +347,12 @@ def _field_loss(
     )
 
     fourier_loss = _fourier_loss(fourier_field, expansion, primitive_lattice_vectors)
-    return alignment_loss + fourier_loss_weight * fourier_loss
+    smoothness_loss = _smoothness_loss(field, primitive_lattice_vectors)
+    return (
+        alignment_loss
+        + fourier_loss_weight * fourier_loss
+        + smoothness_loss_weight * smoothness_loss
+    )
 
 
 def _alignment_loss(
@@ -380,6 +403,12 @@ def _fourier_loss(
     return jnp.sum(jnp.abs(fourier_field) ** 2 * kt[..., jnp.newaxis] ** 2)
 
 
+def _smoothness_loss(field: jnp.ndarray, basis_vectors: jnp.ndarray) -> jnp.ndarray:
+    """Compute loss associated with smoothness of `field`."""
+    grads = _vector_field_forward_difference_gradient(field, basis_vectors)
+    return jnp.mean(jnp.abs(jnp.asarray(grads)) ** 2)
+
+
 # -------------------------------------------------------------------------------------
 # Gradient calculation and transformation.
 # -------------------------------------------------------------------------------------
@@ -420,6 +449,73 @@ def compute_gradient(
     partial_grad = [_unpad(g, pad_width) for g in partial_grad]
     partial_grad = [g * arr.shape[ax] for g, ax in zip(partial_grad, axes)]
     return _transform_gradient(jnp.stack(partial_grad, axis=-1), basis_vectors)
+
+
+def _vector_field_forward_difference_gradient(
+    field: jnp.ndarray,
+    primitive_lattice_vectors: basis.LatticeVectors,
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Computes the gradient of a vector field by forward difference.
+
+    The returned gradient consists of as many arrays as there are dimensions, each
+    having the same shape as `field`. In the three-dimensional case, we have
+
+        grad = (grad_field_x, grad_field_y, grad_field_z)
+
+    where
+
+        grad_field_x = stack([dfield_x / dx, dfield_y / dy, dfield_z / dz], axis=-1)
+
+    Args:
+        field: The field for which the gradient is sought.
+        primitive_lattice_vectors: Defines the unit cell coordinates.
+
+    Returns:
+        Tuple containing the gradients, each iwth the same shape as `field`.
+    """
+    basis_vectors = jnp.stack(
+        [primitive_lattice_vectors.u, primitive_lattice_vectors.v],
+        axis=-1,
+    )
+
+    area = jnp.abs(jnp.linalg.det(basis_vectors))
+    basis_vectors /= jnp.sqrt(area)
+
+    grads = [
+        _scalar_field_forward_difference_gradient(
+            field=field[..., i],
+            basis_vectors=basis_vectors,
+        )
+        for i in range(2)
+    ]
+    return tuple(grads)
+
+
+def _scalar_field_forward_difference_gradient(
+    field: jnp.ndarray,
+    basis_vectors: jnp.ndarray,
+) -> jnp.ndarray:
+    """Computes the gradient of a scalar field by forward difference.
+
+    Args:
+        field: The scalar field for which the forward-difference gradient is sought.
+        basis_vectors: The vectors defining the space in which `field` is defined.
+
+    Returns:
+        The gradient, with shape `field.shape + (dimensions,)`.
+    """
+    dimension = basis_vectors.shape[-1]
+    assert basis_vectors.shape[-2:] == (dimension, dimension)
+    axes = range(field.ndim - dimension, field.ndim)
+    diffs = [_periodic_forward_difference(field, axis=ax) for ax in axes]
+    partial_grad = jnp.stack(diffs, axis=-1)
+    return _transform_gradient(partial_grad, basis_vectors)
+
+
+def _periodic_forward_difference(field: jnp.ndarray, axis: int) -> jnp.ndarray:
+    """Computes the forward difference for `field` along `axis`."""
+    diff = jnp.roll(field, shift=-1, axis=axis) - field
+    return diff * field.shape[axis]
 
 
 def _transform_gradient(

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -403,7 +403,9 @@ def _fourier_loss(
     return jnp.sum(jnp.abs(fourier_field) ** 2 * kt[..., jnp.newaxis] ** 2)
 
 
-def _smoothness_loss(field: jnp.ndarray, basis_vectors: basis.LatticeVectors) -> jnp.ndarray:
+def _smoothness_loss(
+    field: jnp.ndarray, basis_vectors: basis.LatticeVectors
+) -> jnp.ndarray:
     """Compute loss associated with smoothness of `field`."""
     grads = _vector_field_forward_difference_gradient(field, basis_vectors)
     return jnp.mean(jnp.abs(jnp.asarray(grads)) ** 2)

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -403,7 +403,7 @@ def _fourier_loss(
     return jnp.sum(jnp.abs(fourier_field) ** 2 * kt[..., jnp.newaxis] ** 2)
 
 
-def _smoothness_loss(field: jnp.ndarray, basis_vectors: jnp.ndarray) -> jnp.ndarray:
+def _smoothness_loss(field: jnp.ndarray, basis_vectors: basis.LatticeVectors) -> jnp.ndarray:
     """Compute loss associated with smoothness of `field`."""
     grads = _vector_field_forward_difference_gradient(field, basis_vectors)
     return jnp.mean(jnp.abs(jnp.asarray(grads)) ** 2)
@@ -471,7 +471,7 @@ def _vector_field_forward_difference_gradient(
         primitive_lattice_vectors: Defines the unit cell coordinates.
 
     Returns:
-        Tuple containing the gradients, each iwth the same shape as `field`.
+        Tuple containing the gradients, each with the same shape as `field`.
     """
     basis_vectors = jnp.stack(
         [primitive_lattice_vectors.u, primitive_lattice_vectors.v],
@@ -480,15 +480,10 @@ def _vector_field_forward_difference_gradient(
 
     area = jnp.abs(jnp.linalg.det(basis_vectors))
     basis_vectors /= jnp.sqrt(area)
-
-    grads = [
-        _scalar_field_forward_difference_gradient(
-            field=field[..., i],
-            basis_vectors=basis_vectors,
-        )
-        for i in range(2)
-    ]
-    return tuple(grads)
+    return (
+        _scalar_field_forward_difference_gradient(field[..., 0], basis_vectors),
+        _scalar_field_forward_difference_gradient(field[..., 1], basis_vectors),
+    )
 
 
 def _scalar_field_forward_difference_gradient(

--- a/tests/fmmax/test_vector.py
+++ b/tests/fmmax/test_vector.py
@@ -12,6 +12,9 @@ import parameterized
 
 from fmmax import basis, vector
 
+# Enable 64-bit precision for higher accuracy.
+jax.config.update("jax_enable_x64", True)
+
 
 class ChangeBasisTest(unittest.TestCase):
     def test_basis_cycle(self):
@@ -162,8 +165,8 @@ class SchemesTest(unittest.TestCase):
                 expansion=expansion,
                 primitive_lattice_vectors=primitive_lattice_vectors,
             )
-            onp.testing.assert_array_equal(tx[i, :, :], expected_tx_i)
-            onp.testing.assert_array_equal(ty[i, :, :], expected_ty_i)
+            onp.testing.assert_allclose(tx[i, :, :], expected_tx_i)
+            onp.testing.assert_allclose(ty[i, :, :], expected_ty_i)
 
     @parameterized.parameterized.expand(
         [(scheme,) for scheme in vector.VECTOR_FIELD_SCHEMES]

--- a/tests/fmmax/test_vector_fourier.py
+++ b/tests/fmmax/test_vector_fourier.py
@@ -25,6 +25,9 @@ class TangentVectorTest(unittest.TestCase):
         arr_scale,
         binarize_arr,
         use_jones_direct,
+        fourier_loss_weight,
+        smoothness_loss_weight,
+        steps=1,
     ):
         primitive_lattice_vectors = basis.LatticeVectors(
             basis.X * scale, basis.Y * scale
@@ -50,7 +53,9 @@ class TangentVectorTest(unittest.TestCase):
             expansion,
             primitive_lattice_vectors,
             use_jones_direct,
-            fourier_loss_weight=0.001,
+            fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
+            steps=steps,
         )
 
     @parameterized.expand(
@@ -74,7 +79,9 @@ class TangentVectorTest(unittest.TestCase):
             (1000, (80, 80), 1, True, True),  # Binarized, scale invariance.
         ]
     )
-    def test_invariances(self, scale, shape, arr_scale, binarize_arr, use_jones_direct):
+    def test_invariances_fourier_loss(
+        self, scale, shape, arr_scale, binarize_arr, use_jones_direct
+    ):
         reference_tx, reference_ty = self._compute_field(
             approximate_num_terms=200,
             scale=1,
@@ -82,6 +89,8 @@ class TangentVectorTest(unittest.TestCase):
             arr_scale=1,
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
+            fourier_loss_weight=0.001,
+            smoothness_loss_weight=0.0,
         )
         zoom = (shape[0] / 80, shape[1] / 80)
         expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
@@ -94,6 +103,59 @@ class TangentVectorTest(unittest.TestCase):
             arr_scale=arr_scale,
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
+            fourier_loss_weight=0.001,
+            smoothness_loss_weight=0.0,
+        )
+        onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
+        onp.testing.assert_allclose(ty, expected_ty, atol=0.05)
+
+    @parameterized.expand(
+        [
+            # Cases with grayscale density and `use_jones_direct = False`.
+            (1, (160, 120), 1, False, False),  # Resolution invariance.
+            (1000, (80, 80), 1, False, False),  # Scale invariance.
+            (1, (80, 80), (1 + 0j), False, False),  # Phase invariance.
+            (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), False, False),
+            (1, (80, 80), (0 + 1j), False, False),
+            # Cases with binarized density and `use_jones_direct = False`.
+            (1, (160, 120), 1, True, False),  # Resolution invariance.
+            (1000, (80, 80), 1, True, False),  # Scale invariance.
+            (1, (80, 80), (1 + 0j), True, False),  # Phase invariance.
+            (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), True, False),
+            (1, (80, 80), (0 + 1j), True, False),
+            # Cases with `use_jones_direct = True`.
+            (1, (160, 120), 1, False, True),  # Grayscale, resolution invariance.
+            (1000, (80, 80), 1, False, True),  # Grayscale, scale invariance.
+            (1, (160, 120), 1, True, True),  # Binarized, resolution invariance.
+            (1000, (80, 80), 1, True, True),  # Binarized, scale invariance.
+        ]
+    )
+    def test_invariances_smoothness_loss(
+        self, scale, shape, arr_scale, binarize_arr, use_jones_direct
+    ):
+        reference_tx, reference_ty = self._compute_field(
+            approximate_num_terms=200,
+            scale=1,
+            shape=(80, 80),
+            arr_scale=1,
+            binarize_arr=binarize_arr,
+            use_jones_direct=use_jones_direct,
+            fourier_loss_weight=0.0,
+            smoothness_loss_weight=0.1,
+        )
+        zoom = (shape[0] / 80, shape[1] / 80)
+        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
+        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * arr_scale
+
+        tx, ty = self._compute_field(
+            approximate_num_terms=200,
+            scale=scale,
+            shape=shape,
+            arr_scale=arr_scale,
+            binarize_arr=binarize_arr,
+            use_jones_direct=use_jones_direct,
+            fourier_loss_weight=0.0,
+            smoothness_loss_weight=0.1,
         )
         onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
         onp.testing.assert_allclose(ty, expected_ty, atol=0.05)
@@ -121,6 +183,7 @@ class TangentVectorTest(unittest.TestCase):
             primitive_lattice_vectors,
             use_jones_direct=use_jones_direct,
             fourier_loss_weight=0.01,
+            smoothness_loss_weight=1.0,
         )
 
         for i in range(arr.shape[0]):
@@ -130,6 +193,7 @@ class TangentVectorTest(unittest.TestCase):
                 primitive_lattice_vectors,
                 use_jones_direct=use_jones_direct,
                 fourier_loss_weight=0.01,
+                smoothness_loss_weight=1.0,
             )
             onp.testing.assert_allclose(tx, tx_batch[i, :, :], rtol=1e-5)
             onp.testing.assert_allclose(ty, ty_batch[i, :, :], rtol=1e-5)
@@ -150,6 +214,7 @@ class TangentVectorTest(unittest.TestCase):
                 primitive_lattice_vectors=primitive_lattice_vectors,
                 use_jones_direct=use_jones_direct,
                 fourier_loss_weight=0.01,
+                smoothness_loss_weight=0.0,
             )
             return jnp.sum(jnp.abs(tx) ** 2) + jnp.sum(jnp.abs(ty) ** 2)
 
@@ -179,6 +244,7 @@ class TangentVectorTest(unittest.TestCase):
                 primitive_lattice_vectors=primitive_lattice_vectors,
                 use_jones_direct=use_jones_direct,
                 fourier_loss_weight=0.01,
+                smoothness_loss_weight=0.0,
             )
             return jnp.sum(jnp.abs(tx) ** 2) + jnp.sum(jnp.abs(ty) ** 2), (tx, ty)
 
@@ -188,8 +254,42 @@ class TangentVectorTest(unittest.TestCase):
         self.assertFalse(jnp.any(jnp.isnan(ty)))
         self.assertFalse(jnp.any(jnp.isnan(grad)))
 
-    # def test_field_converges(self):
-    #     pass
+    @parameterized.expand(
+        [
+            [True, True, 0.01, 0.0],
+            [False, True, 0.01, 0.0],
+            [True, False, 0.01, 0.0],
+            [False, False, 0.01, 0.0],
+            [True, True, 0.0, 1.0],
+            [False, True, 0.0, 1.0],
+            [True, False, 0.0, 1.0],
+            [False, False, 0.0, 1.0],
+        ]
+    )
+    def test_field_converges(
+        self,
+        binarize_arr,
+        use_jones_direct,
+        fourier_loss_weight,
+        smoothness_loss_weight,
+    ):
+        # Test that a single Newton iteration is sufficient.
+        field_fn = functools.partial(
+            self._compute_field,
+            approximate_num_terms=200,
+            scale=1,
+            shape=(80, 80),
+            arr_scale=1,
+            binarize_arr=binarize_arr,
+            use_jones_direct=use_jones_direct,
+            fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
+        )
+
+        tx, ty = field_fn(steps=2)
+        tx_multi_step, ty_multi_step = field_fn(steps=3)
+        onp.testing.assert_allclose(tx, tx_multi_step, atol=1e-4)
+        onp.testing.assert_allclose(ty, ty_multi_step, atol=1e-4)
 
 
 class NormalizeTest(unittest.TestCase):
@@ -252,6 +352,22 @@ class NormalizeTest(unittest.TestCase):
         self.assertFalse(onp.any(onp.isnan(gx)))
         self.assertFalse(onp.any(onp.isnan(gy)))
 
+    @parameterized.expand(
+        [
+            [vector_fourier.normalize_elementwise],
+            [vector_fourier.normalize],
+            [vector_fourier.normalize_jones],
+        ]
+    )
+    def test_batch_calculation_matches_single(self, normalize_fn):
+        onp.random.seed(0)
+        arr = onp.random.randn(8, 10, 10, 2)
+        arr = ndimage.zoom(arr, (1, 5, 5, 1))
+        normalized = normalize_fn(arr)
+        for i, arr_single in enumerate(arr):
+            normalized_single = normalize_fn(arr_single)
+            onp.testing.assert_array_equal(normalized[i, ...], normalized_single)
+
 
 class MagnitudeTest(unittest.TestCase):
     @parameterized.expand(
@@ -291,68 +407,71 @@ class AngleTest(unittest.TestCase):
         self.assertFalse(onp.any(onp.isnan(grad)))
 
 
-class GradientTest(unittest.TestCase):
-    pass
+class TangentFieldMatchesExpectedTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            [0.01, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    def test_field_pol(self, fourier_loss_weight, smoothness_loss_weight):
+        arr = jnp.array(
+            [[0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]], dtype=jnp.float32
+        )
+        tx, ty = vector_fourier.compute_field_pol(
+            arr,
+            basis.Expansion(
+                basis_coefficients=jnp.asarray(
+                    [[0, 0], [0, 1], [0, -1], [0, 2], [0, -2], [0, 3], [0, -3]]
+                )
+            ),
+            basis.LatticeVectors(basis.X, basis.Y),
+            fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
+        )
+        expected_tx = [
+            [
+                0.085,
+                0.300,
+                0.570,
+                0.840,
+                1.000,
+                0.910,
+                0.550,
+                0.000,
+                -0.550,
+                -0.910,
+                -1.000,
+                -0.840,
+                -0.570,
+                -0.300,
+                -0.085,
+            ]
+        ]
+        onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
+        onp.testing.assert_allclose(ty, 0.0, atol=1e-7)
 
-
-class TestNewtonIteration(unittest.TestCase):
-    pass
-
-
-# class LossTest(unittest.TestCase):
-#     @parameterized.parameterized.expand(
-#         [
-#             (1.0, 0.0, 1.0, 0.0, -1.0),
-#             (-1.0, 0.0, 1.0, 0.0, -1.0),
-#             (0.0, 1.0, 1.0, 0.0, 0.0),
-#         ]
-#     )
-#     def test_self_alignment_loss(self, tx, ty, tx0, ty0, expected):
-#         tx = jnp.asarray(tx)[jnp.newaxis, jnp.newaxis]
-#         ty = jnp.asarray(ty)[jnp.newaxis, jnp.newaxis]
-#         tx0 = jnp.asarray(tx0)[jnp.newaxis, jnp.newaxis]
-#         ty0 = jnp.asarray(ty0)[jnp.newaxis, jnp.newaxis]
-#         loss = vector_fourier._self_alignment_loss(tx, ty, tx0, ty0)
-#         onp.testing.assert_allclose(loss, expected)
-
-#     @parameterized.parameterized.expand(
-#         [
-#             (
-#                 jnp.ones((2, 2)),
-#                 jnp.zeros((2, 2)),
-#                 jnp.ones((2, 2)),
-#                 jnp.zeros((2, 2)),
-#                 -400,
-#             ),
-#             (
-#                 jnp.asarray([[1, 1], [-1, -1], [-1, -1], [1, 1]]),
-#                 jnp.zeros((4, 2)),
-#                 jnp.ones((4, 2)),
-#                 jnp.zeros((4, 2)),
-#                 -768.0,
-#             ),
-#         ]
-#     )
-#     def test_field_loss(self, tx, ty, tx0, ty0, expected):
-#         loss = vector_fourier._field_loss(
-#             tx, ty, tx0, ty0, alignment_weight=100, smoothness_weight=2
-#         )
-#         onp.testing.assert_allclose(loss, expected)
-
-#     def test_field_loss_batch_matches_single(self):
-#         key = jax.random.PRNGKey(0)
-#         tx, ty, tx0, ty0 = jax.random.uniform(key, (4, 8, 5, 10))
-#         loss = vector_fourier._field_loss(
-#             tx, ty, tx0, ty0, alignment_weight=100, smoothness_weight=2
-#         )
-#         expected_loss = 0
-#         for tx_slice, ty_slice, tx0_slice, ty0_slice in zip(tx, ty, tx0, ty0):
-#             expected_loss += vector_fourier._field_loss(
-#                 tx_slice,
-#                 ty_slice,
-#                 tx0_slice,
-#                 ty0_slice,
-#                 alignment_weight=100,
-#                 smoothness_weight=2,
-#             )
-#         onp.testing.assert_allclose(loss, expected_loss, rtol=1e-6)
+    @parameterized.expand(
+        [
+            [0.01, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    def test_optimize_jones(self, fourier_loss_weight, smoothness_loss_weight):
+        arr = jnp.array(
+            [[0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]], dtype=jnp.float32
+        )
+        tx, ty = vector_fourier.compute_field_jones_direct(
+            arr,
+            basis.Expansion(
+                basis_coefficients=jnp.asarray(
+                    [[0, 0], [0, 1], [0, -1], [0, 2], [0, -2], [0, 3], [0, -3]]
+                )
+            ),
+            basis.LatticeVectors(basis.X, basis.Y),
+            fourier_loss_weight=fourier_loss_weight,
+            smoothness_loss_weight=smoothness_loss_weight,
+        )
+        expected_tx_magnitude = jnp.ones_like(arr)
+        onp.testing.assert_allclose(jnp.abs(tx), expected_tx_magnitude)
+        onp.testing.assert_allclose(ty, 0.0, atol=1e-7)


### PR DESCRIPTION
We plan to replace the original vector field formulations (pol, normal, jones, jones_direct) to address #55. 

This PR extends the formulations implemented in the `vector_fourier` module to allow a real-space smoothness loss, similar to what is used in the original formulations. As a next step, we should actually remove the old formulations, and replace them with these new implementations.

The PR also expands testing of the new vector formulations.