### PR TITLE
Switch FMM formulations to new implementation

### DIFF
--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -212,7 +212,6 @@ def _compute_tangent_field_no_batch(
         jnp.stack([jnp.ones(field.shape[:-1]), jnp.zeros(field.shape[:-1])], axis=-1),
         field,
     )
-    print(gx_is_zero, gy_is_zero)
     field = jnp.where(
         ~gx_is_zero & gy_is_zero,
         jnp.stack([jnp.zeros(field.shape[:-1]), jnp.ones(field.shape[:-1])], axis=-1),

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -494,14 +494,13 @@ def _vector_field_forward_difference_gradient(
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Computes the gradient of a vector field by forward difference.
 
-    The returned gradient consists of as many arrays as there are dimensions, each
-    having the same shape as `field`. In the three-dimensional case, we have
+    The returned gradients are,
 
-        grad = (grad_field_x, grad_field_y, grad_field_z)
+        grad = (grad_field_x, grad_field_y)
 
     where
 
-        grad_field_x = stack([dfield_x / dx, dfield_y / dy, dfield_z / dz], axis=-1)
+        grad_field_x = stack([dfield_x / dx, dfield_y / dy], axis=-1)
 
     Args:
         field: The field for which the gradient is sought.

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -121,6 +121,8 @@ def compute_tangent_field(
       - The tangent field is independent of the resolution of the discretized unit
         cell. That is, whether the permittivity distribution is specified with a
         `(100, 100)` or `(200, 200)` shaped array has no impact on the resulting field.
+      - The tangent field is independent of the amplitude of the array from which it is
+        obtained, e.g. the permittivity contrast.
 
     Args:
         arr: The array for which the normal vector field is sought.
@@ -178,8 +180,8 @@ def _compute_tangent_field_no_batch(
     # Rescale the weights so that a supercell containing multiple unit cells and having
     # correspondlingly more terms in the Fourier expansion yields a tangent field
     # identical to that obtained from just a single unit cell.
-    fourier_loss_weight /= (expansion.num_terms / 1000)
-    smoothness_loss_weight /= (expansion.num_terms / 1000)
+    fourier_loss_weight /= expansion.num_terms
+    smoothness_loss_weight /= expansion.num_terms
 
     grid_shape: Tuple[int, int] = arr.shape[-2:]  # type: ignore[assignment]
     arr = _filter_and_adjust_resolution(arr, expansion)

--- a/src/fmmax/vector_fourier.py
+++ b/src/fmmax/vector_fourier.py
@@ -187,10 +187,7 @@ def _compute_tangent_field_no_batch(
     arr = _filter_and_adjust_resolution(arr, expansion)
     grad = compute_gradient(arr, primitive_lattice_vectors)
 
-    # Normalize the gradient if its maximum magnitude exceeds unity.
-    grad_magnitude = _field_magnitude(grad)
-    norm = jnp.maximum(1.0, jnp.amax(grad_magnitude, axis=(-3, -2, -1), keepdims=True))
-    grad /= norm
+    grad = normalize(grad)
 
     elementwise_alignment_weight = _field_magnitude(grad)
 

--- a/tests/examples/test_metal_pillars.py
+++ b/tests/examples/test_metal_pillars.py
@@ -5,8 +5,12 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import unittest
 
+import jax
 import jax.numpy as jnp
 import numpy as onp
+
+# Enable 64-bit precision for higher accuracy.
+jax.config.update("jax_enable_x64", True)
 
 from examples import metal_pillars
 from fmmax import fmm
@@ -22,7 +26,7 @@ class MetalPillarsTest(unittest.TestCase):
             ambient_thickness_nm=0.0,
             formulation=fmm.Formulation.NORMAL,
         )
-        onp.testing.assert_allclose(rte, [0.098347 + 0.099891j], rtol=1e-3)
+        onp.testing.assert_allclose(rte, [0.098257 + 0.098332j], rtol=1e-3)
 
     def test_compute_fields_regression(self):
         (
@@ -48,15 +52,15 @@ class MetalPillarsTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(efields) ** 2, axis=(2, 3, 4, 5)),
                 onp.asarray(
-                    [[0.046332, 0.053933], [1.048159, 1.887793], [0.145415, 0.080543]]
+                    [[0.046205, 0.053076], [1.04755, 1.874822], [0.145197, 0.079207]]
                 ),
-                rtol=6e-3,
+                rtol=0.01,
             )
         with self.subTest("hfields"):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(hfields) ** 2, axis=(2, 3, 4, 5)),
                 onp.asarray(
-                    [[1.038081, 1.833698], [0.004961, 0.003504], [0.045122, 0.050177]]
+                    [[1.037646, 1.827289], [0.004959, 0.003465], [0.045051, 0.049506]]
                 ),
-                rtol=6e-3,
+                rtol=0.01,
             )

--- a/tests/examples/test_uled.py
+++ b/tests/examples/test_uled.py
@@ -32,7 +32,7 @@ class MicroLedTest(unittest.TestCase):
         with self.subTest("extraction efficiency"):
             onp.testing.assert_allclose(
                 extraction_efficiency,
-                [0.661162, 0.687372, 0.310921],
+                [0.48388, 0.47384, 0.260027],
                 atol=1e-3,
             )
 
@@ -41,9 +41,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(efields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [103.71359, 97.317444, 3.21536],
-                    [98.013145, 99.4448, 3.342574],
-                    [53.552944, 53.12181, 3.446113],
+                    [146.0726, 95.23531, 2.807361],
+                    [96.071144, 140.05743, 2.833282],
+                    [52.65253, 50.394245, 3.149207],
                 ],
                 rtol=1e-3,
             )
@@ -53,9 +53,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(hfields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [469.103, 561.54584, 21.604614],
-                    [586.9631, 470.38712, 20.628143],
-                    [351.44754, 341.26596, 9.459166],
+                    [443.65646, 786.21075, 18.77912],
+                    [817.5605, 443.23544, 18.739767],
+                    [433.22864, 421.48523, 7.723214],
                 ],
                 rtol=1e-3,
             )

--- a/tests/fmmax/test_vector_fourier.py
+++ b/tests/fmmax/test_vector_fourier.py
@@ -91,7 +91,7 @@ class TangentVectorTest(unittest.TestCase):
             arr_scale=1,
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
-            fourier_loss_weight=0.001,
+            fourier_loss_weight=0.1,
             smoothness_loss_weight=0.0,
         )
         zoom = (shape[0] / 80, shape[1] / 80)
@@ -105,7 +105,7 @@ class TangentVectorTest(unittest.TestCase):
             arr_scale=arr_scale,
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
-            fourier_loss_weight=0.001,
+            fourier_loss_weight=0.1,
             smoothness_loss_weight=0.0,
         )
         onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
@@ -143,7 +143,7 @@ class TangentVectorTest(unittest.TestCase):
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
             fourier_loss_weight=0.0,
-            smoothness_loss_weight=0.1,
+            smoothness_loss_weight=1.0,
         )
         zoom = (shape[0] / 80, shape[1] / 80)
         expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
@@ -157,21 +157,21 @@ class TangentVectorTest(unittest.TestCase):
             binarize_arr=binarize_arr,
             use_jones_direct=use_jones_direct,
             fourier_loss_weight=0.0,
-            smoothness_loss_weight=0.1,
+            smoothness_loss_weight=1.0,
         )
         onp.testing.assert_allclose(tx, expected_tx, atol=0.05)
         onp.testing.assert_allclose(ty, expected_ty, atol=0.05)
 
     @parameterized.expand(
         [
-            [True, True, 0.001, 0.0],
-            [True, False, 0.001, 0.0],
-            [False, True, 0.001, 0.0],
-            [False, False, 0.001, 0.0],
-            [True, True, 0.0, 0.1],
-            [True, False, 0.0, 0.1],
-            [False, True, 0.0, 0.1],
-            [False, False, 0.0, 0.1],
+            [True, True, 0.1, 0.0],
+            [True, False, 0.1, 0.0],
+            [False, True, 0.1, 0.0],
+            [False, False, 0.1, 0.0],
+            [True, True, 0.0, 1.0],
+            [True, False, 0.0, 1.0],
+            [False, True, 0.0, 1.0],
+            [False, False, 0.0, 1.0],
         ]
     )
     def test_supercell(
@@ -242,7 +242,7 @@ class TangentVectorTest(unittest.TestCase):
             expansion,
             primitive_lattice_vectors,
             use_jones_direct=use_jones_direct,
-            fourier_loss_weight=0.01,
+            fourier_loss_weight=0.1,
             smoothness_loss_weight=1.0,
         )
 
@@ -252,7 +252,7 @@ class TangentVectorTest(unittest.TestCase):
                 expansion,
                 primitive_lattice_vectors,
                 use_jones_direct=use_jones_direct,
-                fourier_loss_weight=0.01,
+                fourier_loss_weight=0.1,
                 smoothness_loss_weight=1.0,
             )
             onp.testing.assert_allclose(tx, tx_batch[i, :, :], rtol=1e-5)
@@ -303,7 +303,7 @@ class TangentVectorTest(unittest.TestCase):
                 expansion=expansion,
                 primitive_lattice_vectors=primitive_lattice_vectors,
                 use_jones_direct=use_jones_direct,
-                fourier_loss_weight=0.01,
+                fourier_loss_weight=0.1,
                 smoothness_loss_weight=0.0,
             )
             return jnp.sum(jnp.abs(tx) ** 2) + jnp.sum(jnp.abs(ty) ** 2), (tx, ty)
@@ -316,10 +316,10 @@ class TangentVectorTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            [True, True, 0.01, 0.0],
-            [False, True, 0.01, 0.0],
-            [True, False, 0.01, 0.0],
-            [False, False, 0.01, 0.0],
+            [True, True, 0.1, 0.0],
+            [False, True, 0.1, 0.0],
+            [True, False, 0.1, 0.0],
+            [False, False, 0.1, 0.0],
             [True, True, 0.0, 1.0],
             [False, True, 0.0, 1.0],
             [True, False, 0.0, 1.0],
@@ -470,7 +470,7 @@ class AngleTest(unittest.TestCase):
 class TangentFieldMatchesExpectedTest(unittest.TestCase):
     @parameterized.expand(
         [
-            [0.01, 0.0],
+            [0.1, 0.0],
             [0.0, 1.0],
         ]
     )
@@ -541,7 +541,7 @@ class TangentFieldMatchesExpectedTest(unittest.TestCase):
                 )
             ),
             basis.LatticeVectors(basis.X, basis.Y),
-            fourier_loss_weight=0.01,
+            fourier_loss_weight=0.1,
             smoothness_loss_weight=0.0,
         )
         onp.testing.assert_allclose(tx, jnp.ones_like(tx), atol=1e-7)
@@ -560,7 +560,7 @@ class TangentFieldMatchesExpectedTest(unittest.TestCase):
                 )
             ),
             basis.LatticeVectors(basis.X, basis.Y),
-            fourier_loss_weight=0.01,
+            fourier_loss_weight=0.1,
             smoothness_loss_weight=0.0,
         )
         onp.testing.assert_allclose(tx, 0.0, atol=1e-7)
@@ -568,7 +568,7 @@ class TangentFieldMatchesExpectedTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            [0.01, 0.0],
+            [0.1, 0.0],
             [0.0, 1.0],
         ]
     )

--- a/tests/fmmax/test_vector_fourier.py
+++ b/tests/fmmax/test_vector_fourier.py
@@ -68,12 +68,16 @@ class TangentVectorTest(unittest.TestCase):
             (1, (80, 80), (1 + 0j), False, False),  # Phase invariance.
             (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), False, False),
             (1, (80, 80), (0 + 1j), False, False),
+            (1, (80, 80), 0.1, False, False),  # Amplitude invariance.
+            (1, (80, 80), 10.0, False, False),
             # Cases with binarized density and `use_jones_direct = False`.
             (1, (160, 120), 1, True, False),  # Resolution invariance.
             (1000, (80, 80), 1, True, False),  # Scale invariance.
             (1, (80, 80), (1 + 0j), True, False),  # Phase invariance.
             (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), True, False),
             (1, (80, 80), (0 + 1j), True, False),
+            (1, (80, 80), 0.1, True, False),
+            (1, (80, 80), 10.0, True, False),
             # Cases with `use_jones_direct = True`.
             (1, (160, 120), 1, False, True),  # Grayscale, resolution invariance.
             (1000, (80, 80), 1, False, True),  # Grayscale, scale invariance.
@@ -95,8 +99,9 @@ class TangentVectorTest(unittest.TestCase):
             smoothness_loss_weight=0.0,
         )
         zoom = (shape[0] / 80, shape[1] / 80)
-        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
-        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * arr_scale
+        norm = arr_scale / jnp.abs(arr_scale)
+        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * norm
+        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * norm
 
         tx, ty = self._compute_field(
             approximate_num_terms=200,
@@ -119,12 +124,16 @@ class TangentVectorTest(unittest.TestCase):
             (1, (80, 80), (1 + 0j), False, False),  # Phase invariance.
             (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), False, False),
             (1, (80, 80), (0 + 1j), False, False),
+            (1, (80, 80), 0.1, False, False),  # Amplitude invariance.
+            (1, (80, 80), 10.0, False, False),
             # Cases with binarized density and `use_jones_direct = False`.
             (1, (160, 120), 1, True, False),  # Resolution invariance.
             (1000, (80, 80), 1, True, False),  # Scale invariance.
             (1, (80, 80), (1 + 0j), True, False),  # Phase invariance.
             (1, (80, 80), (1 / jnp.sqrt(2) + 1j / jnp.sqrt(2)), True, False),
             (1, (80, 80), (0 + 1j), True, False),
+            (1, (80, 80), 0.1, True, False),
+            (1, (80, 80), 10.0, True, False),
             # Cases with `use_jones_direct = True`.
             (1, (160, 120), 1, False, True),  # Grayscale, resolution invariance.
             (1000, (80, 80), 1, False, True),  # Grayscale, scale invariance.
@@ -146,8 +155,9 @@ class TangentVectorTest(unittest.TestCase):
             smoothness_loss_weight=1.0,
         )
         zoom = (shape[0] / 80, shape[1] / 80)
-        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * arr_scale
-        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * arr_scale
+        norm = arr_scale / jnp.abs(arr_scale)
+        expected_tx = ndimage.zoom(reference_tx, zoom, order=1) * norm
+        expected_ty = ndimage.zoom(reference_ty, zoom, order=1) * norm
 
         tx, ty = self._compute_field(
             approximate_num_terms=200,
@@ -202,7 +212,9 @@ class TangentVectorTest(unittest.TestCase):
         )
 
         # Compute the supercell example.
-        supercell_primitive_lattice_vectors = basis.LatticeVectors(basis.X * 2, basis.Y * 2)
+        supercell_primitive_lattice_vectors = basis.LatticeVectors(
+            basis.X * 2, basis.Y * 2
+        )
         supercell_expansion = basis.generate_expansion(
             primitive_lattice_vectors=supercell_primitive_lattice_vectors,
             approximate_num_terms=4 * expansion.num_terms,

--- a/tests/fmmax/test_vector_fourier.py
+++ b/tests/fmmax/test_vector_fourier.py
@@ -267,8 +267,8 @@ class TangentVectorTest(unittest.TestCase):
                 fourier_loss_weight=0.1,
                 smoothness_loss_weight=1.0,
             )
-            onp.testing.assert_allclose(tx, tx_batch[i, :, :], rtol=1e-5)
-            onp.testing.assert_allclose(ty, ty_batch[i, :, :], rtol=1e-5)
+            onp.testing.assert_allclose(tx, tx_batch[i, :, :], atol=1e-6)
+            onp.testing.assert_allclose(ty, ty_batch[i, :, :], atol=1e-6)
 
     @parameterized.expand([[True], [False]])
     def test_gradient_no_nan(self, use_jones_direct):


### PR DESCRIPTION
This PR is a further step to addressing https://github.com/facebookresearch/fmmax/issues/55

- Replace the old pol, jones, jones direct and normal implementations with new implementations that avoid iterative field optimization and instead use a single Newton step to find the optimal vector field.
- Adjust vector field objective so that it depends upon the number of terms in the Fourier expansion, such that the field resulting from a 2x2 supercell with 4x the number of Fourier terms is identical to that of the base unit cell.

The hyperparameters (smoothness loss weight and fourier loss weight) were adjusted to achieve good convergence of simulated quantities with the number of Fourier terms in the expansion. For the uLED, this new implementation gives essentially unchanged results when compared to the earlier implementation (see figure).

![image](https://github.com/facebookresearch/fmmax/assets/30735893/6d4c7f41-4dc8-4991-8fc8-609b8f50fa65)

The old implementations still remain in the code; these should be removed in a follow-up PR.