### PR TITLE
Avoid computing smoothness/fourier loss when weight is zero

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.5.1"
+current_version = "v0.5.2"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.5.1"
+version = "v0.5.2"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.5.1"
+__version__ = "v0.5.2"
 
 from . import (
     basis,


### PR DESCRIPTION
It seems that smoothness loss (used in generating tangent vector fields) can be problematic in some situations: in particular, it seems to result in long compile times on mac.

One option is to use the formulations using the Fourier loss; this penalizes terms corresponding to high frequencies in the Fourier representation of the tangent vector field, rather than directly penalizing non-smoothness of the fields in real space. However, currently the smoothness loss is calculated, even if the smoothness loss weight is zero (i.e. for the Fourier loss formulations). 

In this PR, we update the logic so that Fourier loss and smoothness loss are calculated only if their corresponding weights are nonzero. Performance of the non-Fourier formulations could be investigated as a follow-up.

