### PR TITLE
Use jax.pure_callback

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.5.3"
+current_version = "v0.5.4"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/examples/crystal.py
+++ b/examples/crystal.py
@@ -345,10 +345,7 @@ def simulate_crystal_with_gaussian_beam(
 
         k = 2 * jnp.pi / wavelengths_padded
         z_r = (
-            jnp.pi
-            * beam_waist**2
-            * jnp.sqrt(permittivity_ambient)
-            / wavelengths_padded
+            jnp.pi * beam_waist**2 * jnp.sqrt(permittivity_ambient) / wavelengths_padded
         )
         w_z = beam_waist * jnp.sqrt(1 + (z / z_r) ** 2)
         r = jnp.sqrt(x**2 + y**2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.5.3"
+version = "v0.5.4"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.5.3"
+__version__ = "v0.5.4"
 
 from . import (
     basis,

--- a/src/fmmax/utils.py
+++ b/src/fmmax/utils.py
@@ -8,7 +8,6 @@ from typing import Tuple
 import jax
 import jax.numpy as jnp
 import numpy as onp
-from jax.experimental import host_callback
 
 EPS_EIG = 1e-6
 
@@ -132,10 +131,13 @@ def _eig_host(matrix: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
         with jax.default_device(jax.devices("cpu")[0]):
             return jax.jit(jnp.linalg.eig)(matrix)
 
-    return host_callback.call(
+    return jax.pure_callback(
         _eig_cpu,
+        (
+            jnp.ones(matrix.shape[:-1], dtype=complex),  # Eigenvalues
+            jnp.ones(matrix.shape, dtype=complex),  # Eigenvectors
+        ),
         matrix.astype(complex),
-        result_shape=(eigenvalues_shape, eigenvectors_shape),
     )
 
 

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -261,9 +261,7 @@ class LayerEigensolveTest(unittest.TestCase):
                     expected_eigenvalues, expected_eigenvectors = _sort_eigs(
                         single_result.eigenvalues, single_result.eigenvectors
                     )
-                    onp.testing.assert_allclose(
-                        eigenvalues**2, expected_eigenvalues**2
-                    )
+                    onp.testing.assert_allclose(eigenvalues**2, expected_eigenvalues**2)
                     onp.testing.assert_allclose(
                         result.z_permittivity_matrix[i, j, k, :, :],
                         single_result.z_permittivity_matrix,
@@ -323,9 +321,7 @@ class EigensolveJitTest(unittest.TestCase):
             permittivity=permittivity,
             formulation=formulation,
         )
-        onp.testing.assert_allclose(
-            result.eigenvalues**2, jit_result.eigenvalues**2
-        )
+        onp.testing.assert_allclose(result.eigenvalues**2, jit_result.eigenvalues**2)
 
 
 class AnistropicLayerEigensolveTest(unittest.TestCase):

--- a/tests/fmmax/test_sources.py
+++ b/tests/fmmax/test_sources.py
@@ -322,9 +322,9 @@ class InternalSourcesTest(unittest.TestCase):
             expansion=EXPANSION,
             formulation=fmm.Formulation.FFT,
         )
-        s_matrices_before_source = (
-            s_matrices_after_source
-        ) = scattering.stack_s_matrices_interior([layer_solve_result], [1.0])
+        s_matrices_before_source = s_matrices_after_source = (
+            scattering.stack_s_matrices_interior([layer_solve_result], [1.0])
+        )
         s_matrix_before_source = s_matrices_before_source[-1][0]
         s_matrix_after_source = s_matrices_after_source[-1][0]
         bwd_amplitude_ambient_end, *_ = sources.amplitudes_for_source(

--- a/tests/fmmax/test_utils.py
+++ b/tests/fmmax/test_utils.py
@@ -270,6 +270,16 @@ class EigTest(unittest.TestCase):
         expected_jac = _jacfwd_fd(fn)(matrix)
         onp.testing.assert_allclose(jac, expected_jac, rtol=RTOL_FD)
 
+    def test_can_vmap(self):
+        matrix = jax.random.normal(jax.random.PRNGKey(0), (2, 4, 4))
+        matrix += 1j * jax.random.normal(jax.random.PRNGKey(1), (2, 4, 4))
+
+        batch_eigval, batch_eigvec = utils.eig(matrix)
+        vmap_eigval, vmap_eigvec = jax.vmap(utils.eig)(matrix)
+
+        onp.testing.assert_array_equal(vmap_eigval, batch_eigval)
+        onp.testing.assert_array_equal(vmap_eigvec, vmap_eigvec)
+
 
 class AbsoluteAxesTest(unittest.TestCase):
     @parameterized.parameterized.expand(([(0, 0), 3], [(1, -2), 3]))


### PR DESCRIPTION
Update the eigensolve to use `jax.pure_callback` instead of `jax.experimental.host_callback.call`. This allows vmap over fmmax calculations. Adds a test that exercises vmap.