### PR TITLE
LayerSolveResult stores lower-level quantities

### DIFF
--- a/src/fmmax/fmm_matrices.py
+++ b/src/fmmax/fmm_matrices.py
@@ -10,6 +10,23 @@ import jax.numpy as jnp
 
 from fmmax import basis, fft, utils
 
+
+def omega_script_k_matrix_patterned(
+    wavelength: jnp.ndarray,
+    z_permittivity_matrix: jnp.ndarray,
+    transverse_permeability_matrix: jnp.ndarray,
+    transverse_wavevectors: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute the omega-script-k matrix of equation 26 from [2012 Liu]."""
+    # The script-k matrix from equation 19 of [2012 Liu].
+    script_k_matrix = script_k_matrix_patterned(
+        z_permittivity_matrix, transverse_wavevectors
+    )
+    angular_frequency = utils.angular_frequency_for_wavelength(wavelength)
+    angular_frequency_squared = angular_frequency[..., jnp.newaxis, jnp.newaxis] ** 2
+    return angular_frequency_squared * transverse_permeability_matrix - script_k_matrix
+
+
 # -----------------------------------------------------------------------------
 # Functions to compute the k- and script-k matrices.
 # -----------------------------------------------------------------------------

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -669,7 +669,7 @@ class LayerSolveResultInputValidationTest(unittest.TestCase):
             ("inverse_z_permittivity_matrix", jnp.ones((1,))),
             ("z_permeability_matrix", jnp.ones((1,))),
             ("inverse_z_permeability_matrix", jnp.ones((1,))),
-            ("omega_script_k_matrix", jnp.ones((1,))),
+            ("transverse_permeability_matrix", jnp.ones((1,))),
             ("tangent_vector_field", (jnp.ones((1,)), jnp.ones((1,)))),
         ]
     )
@@ -691,7 +691,7 @@ class LayerSolveResultInputValidationTest(unittest.TestCase):
             "inverse_z_permittivity_matrix": jnp.ones((3, 4, 5, num, num)),
             "z_permeability_matrix": jnp.ones((3, 4, 5, num, num)),
             "inverse_z_permeability_matrix": jnp.ones((3, 4, 5, num, num)),
-            "omega_script_k_matrix": jnp.ones((3, 4, 5, 2 * num, 2 * num)),
+            "transverse_permeability_matrix": jnp.ones((3, 4, 5, 2 * num, 2 * num)),
             "tangent_vector_field": (
                 jnp.ones((1, 1, 2, 64, 60)),
                 jnp.ones((1, 1, 2, 64, 60)),

--- a/tests/fmmax/test_scattering.py
+++ b/tests/fmmax/test_scattering.py
@@ -59,7 +59,9 @@ def _dummy_solve_result(
         inverse_z_permittivity_matrix=_random_normal_complex(keys[3], (dim, dim)),
         z_permeability_matrix=_random_normal_complex(keys[4], (dim, dim)),
         inverse_z_permeability_matrix=_random_normal_complex(keys[5], (dim, dim)),
-        omega_script_k_matrix=_random_normal_complex(keys[6], (2 * dim, 2 * dim)),
+        transverse_permeability_matrix=_random_normal_complex(
+            keys[6], (2 * dim, 2 * dim)
+        ),
         tangent_vector_field=(
             _random_normal_complex(keys[7], (2 * dim, 2 * dim)),
             _random_normal_complex(keys[7], (2 * dim, 2 * dim)),


### PR DESCRIPTION
This PR makes a small change so the `LayerSolveResult` stores lower-level quantities related to permittivity/permeability, rather than some derived quantities. Specifically, the `omega_script_k_matrix` is now included as a property, not as an attribute. To enable this, the `transverse_permeability_matrix` is made an attribtue.