### PR TITLE
Version updated from v0.5.5 to v0.6.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.5.5"
+current_version = "v0.6.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.5.5"
+version = "v0.6.0"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.5.5"
+__version__ = "v0.6.0"
 
 from . import (
     basis,


### PR DESCRIPTION
In this version, LayerSolveResult now includes the vector fields, and stores the transverse permeability matrix rather than the omega_script_k matrix.