### PR TITLE
Fix broadcasting for vector field source

### DIFF
--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -767,8 +767,6 @@ def _numerical_eigensolve(
         expansion=expansion,
     )
 
-    angular_frequency = utils.angular_frequency_for_wavelength(wavelength)
-
     # The k matrix from equation 23 of [2012 Liu], modified for magnetic materials.
     k_matrix = fmm_matrices.k_matrix_patterned(
         z_permeability_matrix, transverse_wavevectors

--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -664,11 +664,13 @@ def _eigensolve_patterned_general_anisotropic_media(
         permeability_yx,
         permeability_yy,
         permeability_zz,
+        vector_field_source,
     ) = _validate_and_broadcast(
         wavelength,
         in_plane_wavevector,
         *permittivities,
         *permeabilities,
+        vector_field_source,
     )
     (
         inverse_z_permittivity_matrix,

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -400,6 +400,8 @@ class AnistropicLayerEigensolveTest(unittest.TestCase):
         uniform_eigenvalues, uniform_eigenvectors = _sort_eigs(
             uniform_result.eigenvalues, uniform_result.eigenvectors
         )
+        vector_field_source = (permittivity_xx + permittivity_yy) / 2
+        vector_field_source = jnp.broadcast_to(vector_field_source, (64, 64))
         patterned_result = fmm._eigensolve_patterned_general_anisotropic_media(
             wavelength=WAVELENGTH,
             in_plane_wavevector=IN_PLANE_WAVEVECTOR,
@@ -420,7 +422,7 @@ class AnistropicLayerEigensolveTest(unittest.TestCase):
             ),
             expansion=EXPANSION,
             formulation=fmm.Formulation.FFT,
-            vector_field_source=(permittivity_xx + permittivity_yy) / 2,
+            vector_field_source=vector_field_source,
         )
         patterned_eigenvalues, patterned_eigenvectors = _sort_eigs(
             patterned_result.eigenvalues, patterned_result.eigenvectors


### PR DESCRIPTION
Previously, simulations involving anisotropic eigensolve and batch dimensions (e.g. multiple wavelengths) would have failed. This fixes the issue.

I also modified the `sources` module, allowing the `amplitudes_for_fields` function to be used without Brillouin zone integration.