### PR TITLE
Support s-matrix generation via scan

### DIFF
--- a/src/fmmax/basis.py
+++ b/src/fmmax/basis.py
@@ -144,8 +144,14 @@ def unit_cell_coordinates(
             indexing="ij",
         )
     )
-    x = i * primitive_lattice_vectors.u[0] + j * primitive_lattice_vectors.v[0]
-    y = i * primitive_lattice_vectors.u[1] + j * primitive_lattice_vectors.v[1]
+    x = (
+        i * primitive_lattice_vectors.u[..., jnp.newaxis, jnp.newaxis, 0]
+        + j * primitive_lattice_vectors.v[..., jnp.newaxis, jnp.newaxis, 0]
+    )
+    y = (
+        i * primitive_lattice_vectors.u[..., jnp.newaxis, jnp.newaxis, 1]
+        + j * primitive_lattice_vectors.v[..., jnp.newaxis, jnp.newaxis, 1]
+    )
     return x, y
 
 
@@ -220,8 +226,12 @@ def brillouin_zone_in_plane_wavevector(
     reciprocal_vectors = primitive_lattice_vectors.reciprocal
     return jnp.stack(
         [
-            2 * jnp.pi * (i * reciprocal_vectors.u[0] + j * reciprocal_vectors.v[0]),
-            2 * jnp.pi * (i * reciprocal_vectors.u[1] + j * reciprocal_vectors.v[1]),
+            2
+            * jnp.pi
+            * (i * reciprocal_vectors.u[..., 0] + j * reciprocal_vectors.v[..., 0]),
+            2
+            * jnp.pi
+            * (i * reciprocal_vectors.u[..., 1] + j * reciprocal_vectors.v[..., 1]),
         ],
         axis=-1,
     )
@@ -244,12 +254,12 @@ def transverse_wavevectors(
     """
     reciprocal_vectors = primitive_lattice_vectors.reciprocal
     kx = in_plane_wavevector[..., 0, jnp.newaxis] + 2 * jnp.pi * (
-        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[0]
-        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[0]
+        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[..., 0]
+        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 0]
     )
     ky = in_plane_wavevector[..., 1, jnp.newaxis] + 2 * jnp.pi * (
-        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[1]
-        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[1]
+        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[..., 1]
+        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 1]
     )
     return jnp.stack([kx, ky], axis=-1)
 

--- a/src/fmmax/fields.py
+++ b/src/fmmax/fields.py
@@ -428,8 +428,8 @@ def fields_on_grid(
     ky = layer_solve_result.in_plane_wavevector[..., 1, jnp.newaxis, jnp.newaxis]
     phase = jnp.exp(1j * (kx * x + ky * y))[..., jnp.newaxis]
     assert (
-        x.shape
-        == y.shape
+        x.shape[-2:]
+        == y.shape[-2:]
         == (shape[0] * num_unit_cells[0], shape[1] * num_unit_cells[1])
     )
 

--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -292,63 +292,80 @@ class LayerSolveResult:
 
         if _incompatible(self.wavelength, self.batch_shape):
             raise ValueError(
-                f"`wavelength` must have compatible batch shape, but got shape {self.wavelength.shape} "
-                f"when `eigenvectors` shape is {self.eigenvectors.shape}."
+                f"`wavelength` must have compatible batch shape, but got shape "
+                f"{self.wavelength.shape} when `eigenvectors` shape is "
+                f"{self.eigenvectors.shape}."
             )
         if _incompatible(self.in_plane_wavevector, self.batch_shape + (2,)):
             raise ValueError(
-                f"`in_plane_wavevector` must have compatible batch shape, but got shape "
-                f"{self.in_plane_wavevector.shape} when `eigenvectors` shape is {self.eigenvectors.shape}."
+                f"`in_plane_wavevector` must have compatible batch shape, but got "
+                f"shape {self.in_plane_wavevector.shape} when `eigenvectors` shape is "
+                f"{self.eigenvectors.shape}."
             )
+        # if _incompatible(self.primitive_lattice_vectors.u, self.batch_shape + (2,)):
+        #     raise ValueError(
+        #         f"`primitive_lattice_vectors.u` must have compatible batch shape, but "
+        #         f"got shape {self.primitive_lattice_vectors.u.shape} when `eigenvectors` "
+        #         f"shape is {self.eigenvectors.shape}."
+        #     )
+        # if _incompatible(self.primitive_lattice_vectors.v, self.batch_shape + (2,)):
+        #     raise ValueError(
+        #         f"`primitive_lattice_vectors.v` must have compatible batch shape, but got "
+        #         f"shape {self.primitive_lattice_vectors.v.shape} when `eigenvectors` shape "
+        #         f"is {self.eigenvectors.shape}."
+        #     )
         if self.expansion.num_terms * 2 != self.eigenvectors.shape[-1]:
             raise ValueError(
-                f"`eigenvectors` must have shape compatible with `expansion.num_terms`, but got shape "
-                f"{self.eigenvectors.shape} when `num_terms` shape is {self.expansion.num_terms}."
+                f"`eigenvectors` must have shape compatible with `expansion.num_terms`, but "
+                f"got shape {self.eigenvectors.shape} when `num_terms` shape is "
+                f"{self.expansion.num_terms}."
             )
         if self.eigenvalues.shape != self.eigenvectors.shape[:-1]:
             raise ValueError(
-                f"`eigenvalues` must have compatible shape, but got shape {self.eigenvalues.shape} "
-                f"when `eigenvectors` shape is {self.eigenvectors.shape}."
+                f"`eigenvalues` must have compatible shape, but got shape "
+                f"{self.eigenvalues.shape} when `eigenvectors` shape is "
+                f"{self.eigenvectors.shape}."
             )
 
         expected_matrix_shape = self.batch_shape + (self.expansion.num_terms,) * 2
         if _incompatible(self.inverse_z_permittivity_matrix, expected_matrix_shape):
             raise ValueError(
-                f"`inverse_z_permittivity_matrix` must have shape compatible with `eigenvectors`, "
-                f"but got shapes {self.inverse_z_permittivity_matrix.shape}  and {self.eigenvectors.shape}."
+                f"`inverse_z_permittivity_matrix` must have shape compatible with "
+                f"`eigenvectors`, but got shapes {self.inverse_z_permittivity_matrix.shape} "
+                f"and {self.eigenvectors.shape}."
             )
         if _incompatible(self.z_permittivity_matrix, expected_matrix_shape):
             raise ValueError(
-                f"`z_permittivity_matrix` must have shape compatible with `eigenvectors`, but got "
-                f"shapes {self.z_permittivity_matrix.shape}  and {self.eigenvectors.shape}."
+                f"`z_permittivity_matrix` must have shape compatible with `eigenvectors`, "
+                f"but got shapes {self.z_permittivity_matrix.shape} and "
+                f"{self.eigenvectors.shape}."
             )
         if _incompatible(self.inverse_z_permeability_matrix, expected_matrix_shape):
             raise ValueError(
-                f"`inverse_z_permeability_matrix` must have shape compatible with `eigenvectors`, "
-                f"but got shapes {self.inverse_z_permeability_matrix.shape}  and {self.eigenvectors.shape}."
+                f"`inverse_z_permeability_matrix` must have shape compatible with "
+                f"`eigenvectors`, but got shapes {self.inverse_z_permeability_matrix.shape} "
+                f"and {self.eigenvectors.shape}."
             )
         if _incompatible(self.z_permeability_matrix, expected_matrix_shape):
             raise ValueError(
-                f"`z_permeability_matrix` must have shape compatible with `eigenvectors`, but got "
-                f"shapes {self.z_permeability_matrix.shape}  and {self.eigenvectors.shape}."
+                f"`z_permeability_matrix` must have shape compatible with `eigenvectors`, "
+                f"but got shapes {self.z_permeability_matrix.shape} and "
+                f"{self.eigenvectors.shape}."
             )
         if _incompatible(self.transverse_permeability_matrix, self.eigenvectors.shape):
             raise ValueError(
-                f"`transverse_permeability_matrix` must have shape compatible with `eigenvectors`, but got "
-                f"shapes {self.transverse_permeability_matrix.shape}  and {self.eigenvectors.shape}."
-            )
-        if self.omega_script_k_matrix.shape != self.eigenvectors.shape:
-            raise ValueError(
-                f"`omega_script_k_matrix` must have shape matching `eigenvectors`, but got "
-                f"shapes {self.omega_script_k_matrix.shape}  and {self.eigenvectors.shape}."
+                f"`transverse_permeability_matrix` must have shape compatible with "
+                f"`eigenvectors`, but got shapes "
+                f"{self.transverse_permeability_matrix.shape} and "
+                f"s{self.eigenvectors.shape}."
             )
 
         if self.tangent_vector_field is not None and (
             self.tangent_vector_field[0].ndim != self.eigenvectors.ndim
         ):
             raise ValueError(
-                f"`tangent_vector_field` must have ndim compatible with `eigenvectors`, but got "
-                f"shapes {self.tangent_vector_field[0]} and {self.eigenvectors}."
+                f"`tangent_vector_field` must have ndim compatible with `eigenvectors`, "
+                f"but got shapes {self.tangent_vector_field[0]} and {self.eigenvectors}."
             )
 
 
@@ -380,8 +397,10 @@ def _eigensolve_uniform_isotropic_media(
     Returns:
         The `LayerSolveResult`.
     """
-    wavelength, in_plane_wavevector, permittivity = _validate_and_broadcast(
-        wavelength, in_plane_wavevector, permittivity
+    wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity = (
+        _validate_and_broadcast(
+            wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity
+        )
     )
     if permittivity.shape[-2:] != (1, 1):
         raise ValueError(
@@ -473,8 +492,10 @@ def _eigensolve_patterned_isotropic_media(
     Returns:
         The `LayerSolveResult`.
     """
-    wavelength, in_plane_wavevector, permittivity = _validate_and_broadcast(
-        wavelength, in_plane_wavevector, permittivity
+    wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity = (
+        _validate_and_broadcast(
+            wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity
+        )
     )
     (
         inverse_z_permittivity_matrix,
@@ -550,6 +571,7 @@ def _eigensolve_uniform_general_anisotropic_media(
     (
         wavelength,
         in_plane_wavevector,
+        primitive_lattice_vectors,
         permittivity_xx,
         permittivity_xy,
         permittivity_yx,
@@ -563,6 +585,7 @@ def _eigensolve_uniform_general_anisotropic_media(
     ) = _validate_and_broadcast(
         wavelength,
         in_plane_wavevector,
+        primitive_lattice_vectors,
         *permittivities,
         *permeabilities,
     )
@@ -654,6 +677,7 @@ def _eigensolve_patterned_general_anisotropic_media(
     (
         wavelength,
         in_plane_wavevector,
+        primitive_lattice_vectors,
         permittivity_xx,
         permittivity_xy,
         permittivity_yx,
@@ -668,6 +692,7 @@ def _eigensolve_patterned_general_anisotropic_media(
     ) = _validate_and_broadcast(
         wavelength,
         in_plane_wavevector,
+        primitive_lattice_vectors,
         *permittivities,
         *permeabilities,
         vector_field_source,
@@ -1012,6 +1037,7 @@ def fourier_matrices_patterned_anisotropic_media(
 def _validate_and_broadcast(
     angular_frequency: jnp.ndarray,
     in_plane_wavevector: jnp.ndarray,
+    primitive_lattice_vectors: basis.LatticeVectors,
     *permittivities: jnp.ndarray,
 ) -> Tuple[jnp.ndarray, ...]:
     """Validates that shapes are compatible and adds required batch dimensions."""
@@ -1028,28 +1054,42 @@ def _validate_and_broadcast(
     if not utils.batch_compatible_shapes(
         angular_frequency.shape,
         in_plane_wavevector.shape[:-1],
+        primitive_lattice_vectors.u.shape[:-1],
+        primitive_lattice_vectors.v.shape[:-1],
         permittivity.shape[:-2],
     ):
         raise ValueError(
-            f"`angular_frequency`, `in_plane_wavevector`, and `permittivity` "
-            f"must be batch-compatible, but got shapes of {angular_frequency.shape}, "
-            f"{in_plane_wavevector.shape}, and {permittivity.shape}."
+            f"`angular_frequency`, `in_plane_wavevector`, `primitive_lattice_vectors` "
+            f"and `permittivity` must be batch-compatible, but got shapes of "
+            f"{angular_frequency.shape}, {in_plane_wavevector.shape}, "
+            f"{primitive_lattice_vectors.u.shape}, {primitive_lattice_vectors.v.shape}, "
+            f"and {permittivity.shape}."
         )
 
     num_batch_dims = max(
         [
             angular_frequency.ndim,
             in_plane_wavevector.ndim - 1,
+            primitive_lattice_vectors.u.ndim - 1,
+            primitive_lattice_vectors.v.ndim - 1,
             permittivity.ndim - 2,
         ]
     )
     angular_frequency = utils.atleast_nd(angular_frequency, n=num_batch_dims)
     in_plane_wavevector = utils.atleast_nd(in_plane_wavevector, n=num_batch_dims + 1)
+    primitive_lattice_vectors = basis.LatticeVectors(
+        u=utils.atleast_nd(primitive_lattice_vectors.u, n=num_batch_dims + 1),
+        v=utils.atleast_nd(primitive_lattice_vectors.v, n=num_batch_dims + 1),
+    )
 
     permittivities = tuple(
         [utils.atleast_nd(p, n=num_batch_dims + 2) for p in permittivities]
     )
-    return (angular_frequency, in_plane_wavevector) + permittivities
+    return (
+        angular_frequency,
+        in_plane_wavevector,
+        primitive_lattice_vectors,
+    ) + permittivities
 
 
 def _select_eigenvalues_sign(eigenvalues: jnp.ndarray) -> jnp.ndarray:

--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -302,18 +302,18 @@ class LayerSolveResult:
                 f"shape {self.in_plane_wavevector.shape} when `eigenvectors` shape is "
                 f"{self.eigenvectors.shape}."
             )
-        # if _incompatible(self.primitive_lattice_vectors.u, self.batch_shape + (2,)):
-        #     raise ValueError(
-        #         f"`primitive_lattice_vectors.u` must have compatible batch shape, but "
-        #         f"got shape {self.primitive_lattice_vectors.u.shape} when `eigenvectors` "
-        #         f"shape is {self.eigenvectors.shape}."
-        #     )
-        # if _incompatible(self.primitive_lattice_vectors.v, self.batch_shape + (2,)):
-        #     raise ValueError(
-        #         f"`primitive_lattice_vectors.v` must have compatible batch shape, but got "
-        #         f"shape {self.primitive_lattice_vectors.v.shape} when `eigenvectors` shape "
-        #         f"is {self.eigenvectors.shape}."
-        #     )
+        if _incompatible(self.primitive_lattice_vectors.u, self.batch_shape + (2,)):
+            raise ValueError(
+                f"`primitive_lattice_vectors.u` must have compatible batch shape, but "
+                f"got shape {self.primitive_lattice_vectors.u.shape} when `eigenvectors` "
+                f"shape is {self.eigenvectors.shape}."
+            )
+        if _incompatible(self.primitive_lattice_vectors.v, self.batch_shape + (2,)):
+            raise ValueError(
+                f"`primitive_lattice_vectors.v` must have compatible batch shape, but got "
+                f"shape {self.primitive_lattice_vectors.v.shape} when `eigenvectors` shape "
+                f"is {self.eigenvectors.shape}."
+            )
         if self.expansion.num_terms * 2 != self.eigenvectors.shape[-1]:
             raise ValueError(
                 f"`eigenvectors` must have shape compatible with `expansion.num_terms`, but "

--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -397,7 +397,7 @@ def _eigensolve_uniform_isotropic_media(
     Returns:
         The `LayerSolveResult`.
     """
-    wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity = (
+    wavelength, in_plane_wavevector, primitive_lattice_vectors, (permittivity,) = (
         _validate_and_broadcast(
             wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity
         )
@@ -492,7 +492,7 @@ def _eigensolve_patterned_isotropic_media(
     Returns:
         The `LayerSolveResult`.
     """
-    wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity = (
+    wavelength, in_plane_wavevector, primitive_lattice_vectors, (permittivity,) = (
         _validate_and_broadcast(
             wavelength, in_plane_wavevector, primitive_lattice_vectors, permittivity
         )
@@ -572,16 +572,18 @@ def _eigensolve_uniform_general_anisotropic_media(
         wavelength,
         in_plane_wavevector,
         primitive_lattice_vectors,
-        permittivity_xx,
-        permittivity_xy,
-        permittivity_yx,
-        permittivity_yy,
-        permittivity_zz,
-        permeability_xx,
-        permeability_xy,
-        permeability_yx,
-        permeability_yy,
-        permeability_zz,
+        (
+            permittivity_xx,
+            permittivity_xy,
+            permittivity_yx,
+            permittivity_yy,
+            permittivity_zz,
+            permeability_xx,
+            permeability_xy,
+            permeability_yx,
+            permeability_yy,
+            permeability_zz,
+        ),
     ) = _validate_and_broadcast(
         wavelength,
         in_plane_wavevector,
@@ -678,17 +680,19 @@ def _eigensolve_patterned_general_anisotropic_media(
         wavelength,
         in_plane_wavevector,
         primitive_lattice_vectors,
-        permittivity_xx,
-        permittivity_xy,
-        permittivity_yx,
-        permittivity_yy,
-        permittivity_zz,
-        permeability_xx,
-        permeability_xy,
-        permeability_yx,
-        permeability_yy,
-        permeability_zz,
-        vector_field_source,
+        (
+            permittivity_xx,
+            permittivity_xy,
+            permittivity_yx,
+            permittivity_yy,
+            permittivity_zz,
+            permeability_xx,
+            permeability_xy,
+            permeability_yx,
+            permeability_yy,
+            permeability_zz,
+            vector_field_source,
+        ),
     ) = _validate_and_broadcast(
         wavelength,
         in_plane_wavevector,
@@ -1039,7 +1043,7 @@ def _validate_and_broadcast(
     in_plane_wavevector: jnp.ndarray,
     primitive_lattice_vectors: basis.LatticeVectors,
     *permittivities: jnp.ndarray,
-) -> Tuple[jnp.ndarray, ...]:
+) -> Tuple[jnp.ndarray, jnp.ndarray, basis.LatticeVectors, Tuple[jnp.ndarray, ...]]:
     """Validates that shapes are compatible and adds required batch dimensions."""
     if not in_plane_wavevector.shape[-1] == 2:
         raise ValueError(
@@ -1089,7 +1093,8 @@ def _validate_and_broadcast(
         angular_frequency,
         in_plane_wavevector,
         primitive_lattice_vectors,
-    ) + permittivities
+        permittivities,
+    )
 
 
 def _select_eigenvalues_sign(eigenvalues: jnp.ndarray) -> jnp.ndarray:

--- a/src/fmmax/pml.py
+++ b/src/fmmax/pml.py
@@ -77,9 +77,9 @@ def apply_uniaxial_pml(
     permittivity_xy = jnp.zeros_like(permittivity)
     permittivity_yx = jnp.zeros_like(permittivity)
 
-    permeability_xx = sy * sz / sx
-    permeability_yy = sx * sz / sy
-    permeability_zz = sx * sy / sz
+    permeability_xx = sy * sz / sx * jnp.ones_like(permittivity)
+    permeability_yy = sx * sz / sy * jnp.ones_like(permittivity)
+    permeability_zz = sx * sy / sz * jnp.ones_like(permittivity)
     permeability_xy = jnp.zeros_like(permittivity)
     permeability_yx = jnp.zeros_like(permittivity)
 

--- a/src/fmmax/scattering.py
+++ b/src/fmmax/scattering.py
@@ -201,8 +201,9 @@ def stack_s_matrix_scan(
     assert layer_thicknesses.ndim == 1
     if layer_solve_results.batch_shape[0] != len(layer_thicknesses):
         raise ValueError(
-            f"`layer_solve_results` and `layer_thicknesses` should have the same "
-            f"length but got {len(layer_solve_results)} and {len(layer_thicknesses)}."
+            f"`layer_solve_results` and `layer_thicknesses` should be compatible (i.e. "
+            f"correspond to the same number of layers) but inferred layer numbers of "
+            f"{layer_solve_results.batch_shape[0]} and {layer_thicknesses.shape[0]}."
         )
 
     eye = utils.diag(jnp.ones(layer_solve_results.eigenvalues.shape[1:], dtype=complex))

--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -150,6 +150,23 @@ def compute_tangent_field(
     arr = utils.atleast_nd(arr, n=3)
     arr = arr.reshape((-1,) + arr.shape[-2:])
 
+    primitive_lattice_vectors = basis.LatticeVectors(
+        u=jnp.broadcast_to(
+            primitive_lattice_vectors.u.reshape((-1, 2)),
+            (
+                arr.shape[0],
+                2,
+            ),
+        ),
+        v=jnp.broadcast_to(
+            primitive_lattice_vectors.v.reshape((-1, 2)),
+            (
+                arr.shape[0],
+                2,
+            ),
+        ),
+    )
+
     field_fn = jax.vmap(
         functools.partial(
             _compute_tangent_field_no_batch,
@@ -158,7 +175,7 @@ def compute_tangent_field(
             smoothness_loss_weight=smoothness_loss_weight,
             steps=steps,
         ),
-        in_axes=(0, None, None),
+        in_axes=(0, None, 0),
     )
     field = field_fn(
         arr,

--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -214,7 +214,7 @@ def _compute_tangent_field_no_batch(
     # Provide a dummy gradient for the 1D case, which avoids possible nans in the
     # Newton solve below. The tangent vector field will be manually specified.
     is_1d, grad_angle = _is_1d_field(grad)
-    dummy_grad = jnp.broadcast_to(jnp.asarray([1, 0], dtype=complex), grad.shape)
+    dummy_grad = jnp.broadcast_to(jnp.asarray([1, 1], dtype=complex), grad.shape)
     grad = jnp.where(is_1d, dummy_grad, grad)
 
     # Compute the target field with which the tangent field should be aligned.

--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -324,7 +324,12 @@ def _filter_and_adjust_resolution(
     """Filter `x` and adjust its resolution for the given `expansion`."""
     y = fft.fft(x, expansion=expansion)
     min_shape = fft.min_array_shape_for_expansion(expansion)
-    doubled_min_shape = (2 * min_shape[0], 2 * min_shape[1])
+    assert x.ndim == 2
+    # Singleton dimensions remain singleton.
+    doubled_min_shape = (
+        min_shape[0] * (2 if x.shape[0] > 1 else 1),
+        min_shape[1] * (2 if x.shape[1] > 1 else 1),
+    )
     return fft.ifft(y, expansion=expansion, shape=doubled_min_shape)
 
 

--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -153,17 +153,11 @@ def compute_tangent_field(
     primitive_lattice_vectors = basis.LatticeVectors(
         u=jnp.broadcast_to(
             primitive_lattice_vectors.u.reshape((-1, 2)),
-            (
-                arr.shape[0],
-                2,
-            ),
+            (arr.shape[0], 2),
         ),
         v=jnp.broadcast_to(
             primitive_lattice_vectors.v.reshape((-1, 2)),
-            (
-                arr.shape[0],
-                2,
-            ),
+            (arr.shape[0], 2),
         ),
     )
 

--- a/tests/fmmax/test_fields.py
+++ b/tests/fmmax/test_fields.py
@@ -147,8 +147,8 @@ class ShapesTest(unittest.TestCase):
             self.assertSequenceEqual(hgx.shape, expected_shape)
             self.assertSequenceEqual(hgy.shape, expected_shape)
             self.assertSequenceEqual(hgz.shape, expected_shape)
-            self.assertSequenceEqual(x.shape, grid_shape)
-            self.assertSequenceEqual(y.shape, grid_shape)
+            self.assertSequenceEqual(x.shape[-2:], grid_shape)
+            self.assertSequenceEqual(y.shape[-2:], grid_shape)
 
 
 class FieldsOnCoordinatesTest(unittest.TestCase):
@@ -186,14 +186,13 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             shape=(20, 20),
             num_unit_cells=(1, 1),
         )
-
         with self.subTest("xy on a square grid"):
-            efield, hfield, _ = fields.fields_on_coordinates(
+            efield, hfield, (x, y) = fields.fields_on_coordinates(
                 electric_field=(ex, ey, ez),
                 magnetic_field=(hx, hy, hz),
                 layer_solve_result=layer_solve_result,
-                x=x,
-                y=y,
+                x=jnp.squeeze(x),
+                y=jnp.squeeze(y),
             )
             onp.testing.assert_allclose(efield, expected_efield, rtol=1e-4)
             onp.testing.assert_allclose(hfield, expected_hfield, rtol=1e-4)
@@ -255,8 +254,8 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
                 layer_solve_result=layer_solve_result,
                 layer_thickness=jnp.ones(()),
                 layer_znum=10,
-                x=x,
-                y=y,
+                x=jnp.squeeze(x),
+                y=jnp.squeeze(y),
             )
             onp.testing.assert_allclose(efield, expected_efield, rtol=2e-4)
             onp.testing.assert_allclose(hfield, expected_hfield, rtol=2e-4)
@@ -304,8 +303,8 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             layer_solve_results=layer_solve_results,
             layer_thicknesses=thicknesses,
             layer_znum=[10] * len(thicknesses),
-            x=x,
-            y=y,
+            x=jnp.squeeze(x),
+            y=jnp.squeeze(y),
         )
         onp.testing.assert_allclose(efield, expected_efield, rtol=1e-4)
         onp.testing.assert_allclose(hfield, expected_hfield, rtol=1e-4)

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -685,7 +685,10 @@ class LayerSolveResultInputValidationTest(unittest.TestCase):
         kwargs = {
             "wavelength": jnp.ones((3, 1, 1)),
             "in_plane_wavevector": jnp.ones((1, 4, 5, 2)),
-            "primitive_lattice_vectors": PRIMITIVE_LATTICE_VECTORS,
+            "primitive_lattice_vectors": basis.LatticeVectors(
+                u=basis.X * jnp.ones((1, 1, 1, 2)),
+                v=basis.Y * jnp.ones((1, 1, 1, 2)),
+            ),
             "expansion": expansion,
             "eigenvalues": jnp.ones((3, 4, 5, 2 * num)),
             "eigenvectors": jnp.ones((3, 4, 5, 2 * num, 2 * num)),

--- a/tests/fmmax/test_sources.py
+++ b/tests/fmmax/test_sources.py
@@ -391,6 +391,8 @@ class InternalSourcesTest(unittest.TestCase):
             shape=(21, 21),
             num_unit_cells=brillouin_grid_shape,
         )
+        x = jnp.squeeze(x)  # Remove batch dimensions from BZ grid.
+        y = jnp.squeeze(y)
 
         # Perform Brillouin zone integration and compute magnetic field magnitude.
         hfield = jnp.mean(jnp.asarray(hfield), axis=(1, 2))
@@ -487,16 +489,16 @@ class AmplitudesFromInternalSourcesTest(unittest.TestCase):
                 atol=1e-08,
             )
         with self.subTest("no reflection in the stack"):
-            onp.testing.assert_allclose(fwd_amplitude_before_start, 0.0, atol=1e-15)
-            onp.testing.assert_allclose(bwd_amplitude_after_end, 0.0, atol=1e-15)
+            onp.testing.assert_allclose(fwd_amplitude_before_start, 0.0, atol=1e-12)
+            onp.testing.assert_allclose(bwd_amplitude_after_end, 0.0, atol=1e-12)
         with self.subTest("check polarization"):
             te, tm = jnp.split(bwd_amplitude_before_end, 2, axis=-2)
             if te_expected_zero:
-                onp.testing.assert_allclose(te, 0.0, rtol=1e-05, atol=1e-08)
+                onp.testing.assert_allclose(te, 0.0, rtol=1e-05, atol=1e-06)
             else:
                 self.assertFalse(onp.allclose(te, 0.0))
             if tm_expected_zero:
-                onp.testing.assert_allclose(tm, 0.0, rtol=1e-05, atol=1e-08)
+                onp.testing.assert_allclose(tm, 0.0, rtol=1e-05, atol=1e-06)
             else:
                 self.assertFalse(onp.allclose(tm, 0.0))
 


### PR DESCRIPTION
Adds a new `stack_s_matrix_scan` function to `scattering` module which computes scattering matrix by scan, rather than with python for loop. This could reduce compile time and program size in cases where the number of layers is large.

The "best" way to make use of this functionality is to also compute the layer eigensolves on a batch of permittivities (with leading match dimension corresponding to the layer).

To support this change, we also enabled batch dimensions for `LatticeVectors` objects throughout. This is needed in this context, because it puts the `primitive_lattice_vectors` attribute of the `LayerSolveResult` on the same footing as all other attributes (i.e. it is no longer a special attribute without batch dimensions).

Note that the spatial coordinates now also can have batch dimensions, which are singleton and squeezed out in several tests. This may be relevant when computing fields or sources.