### PR TITLE
Improve vjp for `eig`

### DIFF
--- a/src/fmmax/utils.py
+++ b/src/fmmax/utils.py
@@ -160,12 +160,14 @@ def _eig_bwd(
     grad_eigenvalues, grad_eigenvectors = grads
 
     # Compute the F-matrix, from equation 5 of [2021 Colburn]. This applies a
-    # Lorentzian broadening to the matrix `f = 1 / (eigenvalues[i] - eigenvalues[j])`.
+    # Lorentzian broadening to the matrix `f = 1 / (eigenvalues[i].conj -
+    # eigenvalues[j])`. Note that our implementation here differs both from the
+    # code and the paper.
+    # TODO: derive the proper expression for broadened F-matrix.
     eigenvalues_i = eigenvalues[..., jnp.newaxis, :]
     eigenvalues_j = eigenvalues[..., :, jnp.newaxis]
-    f_broadened = (eigenvalues_i - eigenvalues_j) / (
-        (eigenvalues_i - eigenvalues_j) ** 2 + eps
-    )
+    delta_eig = eigenvalues_i - eigenvalues_j
+    f_broadened = delta_eig.conj() / (jnp.abs(delta_eig) ** 2 + eps)
 
     # Manually set the diagonal elements to zero, as we do not use broadening here.
     i = jnp.arange(f_broadened.shape[-1])

--- a/src/fmmax/utils.py
+++ b/src/fmmax/utils.py
@@ -159,10 +159,8 @@ def _eig_bwd(
     eigenvalues, eigenvectors, eps = res
     grad_eigenvalues, grad_eigenvectors = grads
 
-    # Compute the F-matrix, from equation 5 of [2021 Colburn]. This applies a
-    # Lorentzian broadening to the matrix `f = 1 / (eigenvalues[i].conj -
-    # eigenvalues[j])`. Note that our implementation here differs both from the
-    # code and the paper.
+    # Compute the broadened F-matrix. The expression is similar to that of equation 5
+    # from [2021 Colburn], but differs slightly from both the code and paper.
     # TODO: derive the proper expression for broadened F-matrix.
     eigenvalues_i = eigenvalues[..., jnp.newaxis, :]
     eigenvalues_j = eigenvalues[..., :, jnp.newaxis]

--- a/tests/fmmax/test_grad_finite_difference.py
+++ b/tests/fmmax/test_grad_finite_difference.py
@@ -24,11 +24,11 @@ def gaussian_permittivity_fn(x0, y0, dim):
 class FiniteDifferenceGradientTest(unittest.TestCase):
     @parameterized.expand(
         [
-            (fmm.Formulation.FFT, 1e-2),
+            (fmm.Formulation.FFT, 3e-3),
             (fmm.Formulation.JONES_DIRECT, 1e-2),
             (fmm.Formulation.JONES_DIRECT_FOURIER, 1e-2),
             (fmm.Formulation.POL, 2e-2),
-            (fmm.Formulation.POL_FOURIER, 3e-2),
+            (fmm.Formulation.POL_FOURIER, 2e-2),
         ]
     )
     def test_gradient_matches_expected(self, formulation, rtol):


### PR DESCRIPTION
As discussed #105, there is an opportunity to improve the eig vjp.

This PR makes the suggested change, which allows slight tightening of tolerances in some gradient calculation tests.