### PR TITLE
Eliminate batched 1D solve

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.8.0"
+current_version = "v0.8.1"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.8.0"
+version = "v0.8.1"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.8.0"
+__version__ = "v0.8.1"
 
 from . import (
     basis,

--- a/src/fmmax/beams.py
+++ b/src/fmmax/beams.py
@@ -66,14 +66,14 @@ def shifted_rotated_fields(
     # which, when rotated as specified, give us the locations `(x, y, z)`.
     assert x.shape == y.shape == z.shape
     coords = jnp.stack([x, y, z], axis=-1)
-    rotated_coords = jnp.linalg.solve(mat, coords)
+    rotated_coords = jnp.linalg.solve(mat, coords[..., jnp.newaxis])[..., 0]
     rotated_coords = jnp.split(rotated_coords, 3, axis=-1)
     xf, yf, zf = [jnp.squeeze(r, axis=-1) for r in rotated_coords]
 
     # Solve for the rotated origin.
     origin = jnp.stack([beam_origin_x, beam_origin_y, beam_origin_z], axis=-1)
     origin = jnp.expand_dims(origin, range(0, mat.ndim - 2))
-    rotated_origin = jnp.linalg.solve(mat, origin)
+    rotated_origin = jnp.linalg.solve(mat, origin[..., jnp.newaxis])[..., 0]
     assert rotated_origin.size == 3
     rotated_origin = jnp.split(rotated_origin, 3, axis=-1)
     xf0, yf0, zf0 = [jnp.squeeze(r) for r in rotated_origin]


### PR DESCRIPTION
Eliminates the following warning:

```
FutureWarning: jnp.linalg.solve: batched 1D solves with b.ndim > 1 are deprecated, and in the future will be treated as a batched 2D solve. Use solve(a, b[..., None])[..., 0] to avoid this warning.
```