### PR TITLE
Unpin numpy for grcwa tests

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.9.0"
+current_version = "v0.9.1"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Setup environment
         run: |
             python -m pip install --upgrade pip
-            pip install "numpy<2"
             pip install ".[tests,dev]"
       - name: Test grcwa
         run: pytest tests/grcwa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.9.0"
+version = "v0.9.1"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.9.0"
+__version__ = "v0.9.1"
 
 from . import (
     basis,

--- a/src/fmmax/utils.py
+++ b/src/fmmax/utils.py
@@ -15,9 +15,9 @@ import jax.numpy as jnp
 try:
     import jeig
 
-    _JEIG_AVALABLE = True
+    _JEIG_AVAILABLE = True
 except ModuleNotFoundError:
-    _JEIG_AVALABLE = False
+    _JEIG_AVAILABLE = False
 
 
 EIG_EPS_RELATIVE = 1e-12
@@ -157,7 +157,7 @@ def _eig_host_jax(matrix: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
 
 def _eig(matrix: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Eigendecomposition using `jeig` if available, and `_eig_host_jax` if not."""
-    if _JEIG_AVALABLE:
+    if _JEIG_AVAILABLE:
         return jeig.eig(matrix)
     else:
         return _eig_host_jax(matrix)


### PR DESCRIPTION
A new version of autograd has been released, which should be compatible with new versions of numpy. Thus, we can unpin numpy dependency for grcwa tests (which depend on autograd).

Also fixes a typo in the `utils` module.