### PR TITLE
redheffer star product

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.9.1"
+current_version = "v0.10.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.9.1"
+version = "v0.10.0"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ maintainers = [
 
 # TODO add gpu channels
 dependencies = [
-  "jax",
+  "jax <= 0.4.31",
   "jaxlib",
   "numpy",
 ]

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.9.1"
+__version__ = "v0.10.0"
 
 from . import (
     basis,

--- a/tests/fmmax/test_scattering.py
+++ b/tests/fmmax/test_scattering.py
@@ -325,62 +325,58 @@ class ChangeLayerThicknessTest(unittest.TestCase):
 
 
 class RedhefferStarProductTest(unittest.TestCase):
-   def test_star_product(self):
-       layer_solve_results = [
-           _dummy_solve_result(jax.random.PRNGKey(0)),
-           _dummy_solve_result(jax.random.PRNGKey(1)),
-           _dummy_solve_result(jax.random.PRNGKey(2)),
-           _dummy_solve_result(jax.random.PRNGKey(3)),
-           _dummy_solve_result(jax.random.PRNGKey(4)),
-           _dummy_solve_result(jax.random.PRNGKey(5)),
-       ]
-       layer_thicknesses = [0.3, 0.7, 0.2, 0.9, 1.2, 0.4]
-       a = scattering.stack_s_matrix(
-           layer_solve_results=layer_solve_results[:3],
-           layer_thicknesses=layer_thicknesses[:3],
-       )
-       b = scattering.stack_s_matrix(
-           layer_solve_results=layer_solve_results[3:],
-           layer_thicknesses=layer_thicknesses[3:],
-       )
+    def test_star_product(self):
+        layer_solve_results = [
+            _dummy_solve_result(jax.random.PRNGKey(0)),
+            _dummy_solve_result(jax.random.PRNGKey(1)),
+            _dummy_solve_result(jax.random.PRNGKey(2)),
+            _dummy_solve_result(jax.random.PRNGKey(3)),
+            _dummy_solve_result(jax.random.PRNGKey(4)),
+            _dummy_solve_result(jax.random.PRNGKey(5)),
+        ]
+        layer_thicknesses = [0.3, 0.7, 0.2, 0.9, 1.2, 0.4]
+        a = scattering.stack_s_matrix(
+            layer_solve_results=layer_solve_results[:3],
+            layer_thicknesses=layer_thicknesses[:3],
+        )
+        b = scattering.stack_s_matrix(
+            layer_solve_results=layer_solve_results[3:],
+            layer_thicknesses=layer_thicknesses[3:],
+        )
 
+        expected = scattering.stack_s_matrix(
+            layer_solve_results=layer_solve_results,
+            layer_thicknesses=layer_thicknesses,
+        )
+        result = scattering.redheffer_star_product(a, b)
 
-       expected = scattering.stack_s_matrix(
-           layer_solve_results=layer_solve_results,
-           layer_thicknesses=layer_thicknesses,
-       )
-       result = scattering.redheffer_star_product(a, b)
+        with self.subTest("s11"):
+            onp.testing.assert_allclose(result.s11, expected.s11)
+        with self.subTest("s12"):
+            onp.testing.assert_allclose(result.s12, expected.s12)
+        with self.subTest("s21"):
+            onp.testing.assert_allclose(result.s21, expected.s21)
+        with self.subTest("s22"):
+            onp.testing.assert_allclose(result.s22, expected.s22)
 
+        with self.subTest("start_layer_thickness"):
+            onp.testing.assert_array_equal(
+                result.start_layer_thickness, expected.start_layer_thickness
+            )
+        with self.subTest("end_layer_thickness"):
+            onp.testing.assert_array_equal(
+                result.end_layer_thickness, expected.end_layer_thickness
+            )
+        with self.subTest("start_layer_solve_result"):
+            for r, e in zip(
+                tree_util.tree_leaves(result.start_layer_solve_result),
+                tree_util.tree_leaves(expected.start_layer_solve_result),
+            ):
+                onp.testing.assert_array_equal(r, e)
 
-       with self.subTest("s11"):
-           onp.testing.assert_allclose(result.s11, expected.s11)
-       with self.subTest("s12"):
-           onp.testing.assert_allclose(result.s12, expected.s12)
-       with self.subTest("s21"):
-           onp.testing.assert_allclose(result.s21, expected.s21)
-       with self.subTest("s22"):
-           onp.testing.assert_allclose(result.s22, expected.s22)
-
-
-       with self.subTest("start_layer_thickness"):
-           onp.testing.assert_array_equal(
-               result.start_layer_thickness, expected.start_layer_thickness
-           )
-       with self.subTest("end_layer_thickness"):
-           onp.testing.assert_array_equal(
-               result.end_layer_thickness, expected.end_layer_thickness
-           )
-       with self.subTest("start_layer_solve_result"):
-           for r, e in zip(
-               tree_util.tree_leaves(result.start_layer_solve_result),
-               tree_util.tree_leaves(expected.start_layer_solve_result),
-           ):
-               onp.testing.assert_array_equal(r, e)
-
-
-       with self.subTest("end_layer_solve_result"):
-           for r, e in zip(
-               tree_util.tree_leaves(result.end_layer_solve_result),
-               tree_util.tree_leaves(expected.end_layer_solve_result),
-           ):
-               onp.testing.assert_array_equal(r, e)
+        with self.subTest("end_layer_solve_result"):
+            for r, e in zip(
+                tree_util.tree_leaves(result.end_layer_solve_result),
+                tree_util.tree_leaves(expected.end_layer_solve_result),
+            ):
+                onp.testing.assert_array_equal(r, e)


### PR DESCRIPTION
Implement Redheffer star product. Expression deviates slightly from the literature due to the difference in s-matrix convention.

Test compares scattering matrices generated by (1) appending one layer at a time, and (2) creating s-matrices for top and bottom, and then joining those with the Redheffer star product.