### PR TITLE
Field generation, type promotion, and scattering matrices

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.10.1"
+current_version = "v0.11.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "fmmax"
-version = "v0.10.1"
+version = "v0.11.0"
 description = "Fourier modal method with Jax"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/fmmax/__init__.py
+++ b/src/fmmax/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-__version__ = "v0.10.1"
+__version__ = "v0.11.0"
 
 from . import (
     basis,

--- a/src/fmmax/beams.py
+++ b/src/fmmax/beams.py
@@ -122,13 +122,21 @@ def rotation_matrix(
     Returns:
         The rotation matrix.
     """
+    dtype = jnp.promote_types(
+        jnp.asarray(polar_angle).dtype,
+        jnp.promote_types(
+            jnp.asarray(azimuthal_angle).dtype,
+            jnp.asarray(polarization_angle).dtype,
+        ),
+    )
     # Matrix that rotates around the y-axis by `polar_angle`.
     rotation_y_matrix = jnp.asarray(
         [
             [jnp.cos(polar_angle), 0.0, jnp.sin(polar_angle)],
             [0.0, 1.0, 0.0],
             [-jnp.sin(polar_angle), 0.0, jnp.cos(polar_angle)],
-        ]
+        ],
+        dtype=dtype,
     )
 
     # Matrix that rotates around the z-axis by `azimuthal_angle`.
@@ -137,7 +145,8 @@ def rotation_matrix(
             [jnp.cos(azimuthal_angle), -jnp.sin(azimuthal_angle), 0.0],
             [jnp.sin(azimuthal_angle), jnp.cos(azimuthal_angle), 0.0],
             [0.0, 0.0, 1.0],
-        ]
+        ],
+        dtype=dtype,
     )
 
     # Matrix that rotates around the axis defined by the specified polar and
@@ -164,6 +173,7 @@ def rotation_matrix(
                 uz * uy * (1 - cos_theta_p) + ux * sin_theta_p,
                 cos_theta_p + uz**2 * (1 - cos_theta_p),
             ],
-        ]
+        ],
+        dtype=dtype,
     )
     return rotation_p_matrix @ rotation_z_matrix @ rotation_y_matrix

--- a/src/fmmax/farfield.py
+++ b/src/fmmax/farfield.py
@@ -259,7 +259,7 @@ def _integrated_flux_weights(
 
     # The weights are just the gradient of the integrated flux with respect
     # to the flat array elements; use a dummy flux having a single source.
-    dummy_flux = jnp.ones(flux.shape[:-1] + (1,))
+    dummy_flux = jnp.ones_like(flux, shape=flux.shape[:-1] + (1,))
     return jax.grad(_integrated_fn)(dummy_flux)
 
 

--- a/src/fmmax/fft.py
+++ b/src/fmmax/fft.py
@@ -32,7 +32,7 @@ def fourier_convolution_matrix(
     _validate_shape_for_expansion(x.shape, expansion)
 
     x_fft = jnp.fft.fft2(x)
-    x_fft /= jnp.prod(jnp.asarray(x.shape[-2:]))
+    x_fft /= jnp.prod(jnp.asarray(x.shape[-2:])).astype(x.dtype)
     idx = _standard_toeplitz_indices(expansion)
     return x_fft[..., idx[..., 0], idx[..., 1]]
 

--- a/src/fmmax/fields.py
+++ b/src/fmmax/fields.py
@@ -142,11 +142,11 @@ def amplitude_poynting_flux(
     alpha_e = A @ forward_amplitude
     beta_e = A @ backward_amplitude
 
-    s_forward = jnp.asarray(0.5) * (
+    s_forward = jnp.asarray(0.5, dtype=forward_amplitude.dtype) * (
         (jnp.conj(alpha_e) * alpha_h + jnp.conj(alpha_h) * alpha_e)
         + (jnp.conj(beta_h) * alpha_e - jnp.conj(beta_e) * alpha_h)
     )
-    s_backward = jnp.asarray(0.5) * (
+    s_backward = jnp.asarray(0.5, dtype=forward_amplitude.dtype) * (
         -(jnp.conj(beta_e) * beta_h + jnp.conj(beta_h) * beta_e)
         + jnp.conj((jnp.conj(beta_h) * alpha_e - jnp.conj(beta_e) * alpha_h))
     )
@@ -267,7 +267,11 @@ def _poynting_flux_a_matrix(layer_solve_result: fmm.LayerSolveResult) -> jnp.nda
     angular_frequency = utils.angular_frequency_for_wavelength(
         layer_solve_result.wavelength
     )[..., jnp.newaxis]
-    return omega_script_k @ phi @ utils.diag(jnp.ones(()) / (angular_frequency * q))
+    return (
+        omega_script_k
+        @ phi
+        @ utils.diag(jnp.ones((), dtype=q.dtype) / (angular_frequency * q))
+    )
 
 
 def fields_from_wave_amplitudes(
@@ -358,7 +362,11 @@ def field_conversion_matrix(layer_solve_result: fmm.LayerSolveResult) -> jnp.nda
     # Note that there is a factor of `angular_frequency` in the denominator here, which
     # differs from equation 35 in [2012 Liu]. This is an error in that reference, and
     # the factor is actually present e.g. in equation 59.
-    mat = omega_script_k @ phi @ utils.diag(jnp.ones(()) / (angular_frequency * q))
+    mat = (
+        omega_script_k
+        @ phi
+        @ utils.diag(jnp.ones((), dtype=q.dtype) / (angular_frequency * q))
+    )
     return jnp.block([[mat, -mat], [phi, phi]])
 
 

--- a/src/fmmax/fmm.py
+++ b/src/fmmax/fmm.py
@@ -453,7 +453,12 @@ def _eigensolve_uniform_isotropic_media(
         permittivity[..., jnp.newaxis], batch_shape + (expansion.num_terms,)
     )
     z_permittivity_matrix = utils.diag(z_permittivity_matrix)
-    z_permeability_matrix = utils.diag(jnp.ones(z_permittivity_matrix.shape[:-1]))
+    z_permeability_matrix = utils.diag(
+        jnp.ones(
+            z_permittivity_matrix.shape[:-1],
+            dtype=z_permittivity_matrix.dtype,
+        )
+    )
     return LayerSolveResult(
         wavelength=wavelength,
         in_plane_wavevector=in_plane_wavevector,
@@ -516,7 +521,10 @@ def _eigensolve_patterned_isotropic_media(
     )
 
     # Create permeability matrices for nonmagnetic materials.
-    ones = jnp.ones(z_permittivity_matrix.shape[:-1])
+    ones = jnp.ones(
+        z_permittivity_matrix.shape[:-1],
+        dtype=z_permittivity_matrix.dtype,
+    )
     zeros = jnp.zeros_like(ones)
     z_permeability_matrix = utils.diag(ones)
     inverse_z_permeability_matrix = utils.diag(ones)

--- a/src/fmmax/scattering.py
+++ b/src/fmmax/scattering.py
@@ -155,7 +155,7 @@ def _stack_s_matrices(
     # The initial scattering matrix is just the identity matrix, with the
     # necessary batch dimensions.
     eye = utils.diag(jnp.ones_like(layer_solve_results[0].eigenvalues))
-    s_matrix = ScatteringMatrix(
+    layer_s_matrix_0 = ScatteringMatrix(
         s11=eye,
         s12=jnp.zeros_like(eye),
         s21=jnp.zeros_like(eye),
@@ -165,11 +165,17 @@ def _stack_s_matrices(
         end_layer_solve_result=layer_solve_results[0],
         end_layer_thickness=layer_thicknesses[0],
     )
+    layer_s_matrix_1 = _pair_s_matrix(
+        layer_solve_result=layer_solve_results[0],
+        layer_thickness=layer_thicknesses[0],
+        next_layer_solve_result=layer_solve_results[1],
+        next_layer_thickness=layer_thicknesses[1],
+    )
 
     # TODO(mfschubert): Figure out how to use `jax.lax.fori_loop` or similar.
-    s_matrices = [s_matrix]
+    s_matrices = [layer_s_matrix_0, layer_s_matrix_1]
     for layer_solve_result, layer_thickness in zip(
-        layer_solve_results[1:], layer_thicknesses[1:]
+        layer_solve_results[2:], layer_thicknesses[2:]
     ):
         s_matrices.append(
             append_layer(s_matrices[-1], layer_solve_result, layer_thickness)
@@ -181,7 +187,7 @@ def stack_s_matrix_scan(
     layer_solve_results: fmm.LayerSolveResult,
     layer_thicknesses: jnp.ndarray,
 ) -> ScatteringMatrix:
-    """Computes the stack matrix for a stack of layers.
+    """Computes the scattering matrix for a stack of layers by a scan operation.
 
     Unlike `stack_s_matrix`, this function uses a scan operation rather than a python
     for loop, which can lead to significantly smaller programs and shorter compile times.
@@ -375,11 +381,11 @@ def _extend_s_matrix(
     # term1 = diag(q) @ phi_T @ next_omega_k @ next_phi @ diag(1 / next_q)
     # term1 = q[..., :, jnp.newaxis] * jnp.linalg.solve(
     #     omega_k @ phi,
-    #     next_omega_k @ next_phi * (1 / next_q)[..., jnp.newaxis, :],
+    #     next_omega_k @ next_phi @ diag(1 / next_q),
     # )
-    term1 = utils.diag(q) @ jnp.linalg.solve(
+    term1 = q[..., jnp.newaxis] * jnp.linalg.solve(
         omega_k @ phi,
-        next_omega_k @ next_phi @ utils.diag(1 / next_q),
+        next_omega_k @ next_phi * (1 / next_q)[..., jnp.newaxis, :],
     )
     # term2 = phi_T @ omega_k @ next_phi
     term2 = jnp.linalg.solve(omega_k @ phi, omega_k @ next_phi)
@@ -388,23 +394,73 @@ def _extend_s_matrix(
 
     # Phase terms \hat{f}(d) defined near equation 4.2 of [1999 Whittaker]. These
     # describe phase accumulated by propagating across a layer for each eigenmode.
-    fd = utils.diag(jnp.exp(1j * q * layer_thickness))
-    fd_next = utils.diag(jnp.exp(1j * next_q * next_layer_thickness))
+    fd = jnp.exp(1j * q * layer_thickness)
+    fd_next = jnp.exp(1j * next_q * next_layer_thickness)
 
     # Update the s-matrix to include the present layer, following the recipe
     # given in equation 5.4 of [1999 Whittaker].
     s11, s12, s21, s22 = s_matrix_blocks
 
     # s11_next = inv(i11 - diag(fd) @ s12 @ i21) @ diag(fd) @ s11
-    term3 = i11 - fd @ s12 @ i21
-    s11_next = jnp.linalg.solve(term3, fd @ s11)
+    term3 = i11 - fd[..., jnp.newaxis] * s12 @ i21
+    s11_next = jnp.linalg.solve(term3, fd[..., jnp.newaxis] * s11)
     # s12_next = inv(i11 - diag(fd) @ s12 @ i21) @ (diag(fd) @ s12 @ i22 - i12) @ diag(fd_next)
-    s12_next = jnp.linalg.solve(term3, (fd @ s12 @ i22 - i12) @ fd_next)
+    s12_next = jnp.linalg.solve(
+        term3,
+        (fd[..., jnp.newaxis] * s12 @ i22 - i12) * fd_next[..., jnp.newaxis, :],
+    )
     s21_next = s22 @ i21 @ s11_next + s21
     # s22_next = s22 @ i21 @ s12_next + s22 @ i22 @ diag(fd_next)
-    s22_next = s22 @ i21 @ s12_next + s22 @ i22 @ fd_next
+    s22_next = s22 @ i21 @ s12_next + s22 @ i22 * fd_next[..., jnp.newaxis, :]
 
     return (s11_next, s12_next, s21_next, s22_next)
+
+
+def _pair_s_matrix(
+    layer_solve_result: fmm.LayerSolveResult,
+    layer_thickness: jnp.ndarray,
+    next_layer_solve_result: fmm.LayerSolveResult,
+    next_layer_thickness: jnp.ndarray,
+) -> ScatteringMatrix:
+    """Generate the scattering matrix for a pair of layers."""
+    # Alias for brevity: eigenvalues, eigenvectors, and omega-k matrix.
+    q = layer_solve_result.eigenvalues
+    phi = layer_solve_result.eigenvectors
+    omega_k = layer_solve_result.omega_script_k_matrix
+
+    next_q = next_layer_solve_result.eigenvalues
+    next_phi = next_layer_solve_result.eigenvectors
+    next_omega_k = next_layer_solve_result.omega_script_k_matrix
+
+    term1 = q[..., jnp.newaxis] * jnp.linalg.solve(
+        omega_k @ phi,
+        next_omega_k @ next_phi * (1 / next_q)[..., jnp.newaxis, :],
+    )
+
+    term2 = jnp.linalg.solve(omega_k @ phi, omega_k @ next_phi)
+    i11 = i22 = 0.5 * (term1 + term2)
+    i12 = i21 = 0.5 * (-term1 + term2)
+
+    fd = jnp.exp(1j * q * layer_thickness)
+    fd_next = jnp.exp(1j * next_q * next_layer_thickness)
+
+    # The computation is identical to that in `_extend_s_matrix` with `s11` and `s22`
+    # being the identity, and `s12` and `s21` being zero.
+    s11 = jnp.linalg.solve(i11, utils.diag(fd))
+    s12 = jnp.linalg.solve(i11, -i12 * fd_next[..., jnp.newaxis, :])
+    s21 = i21 @ s11
+    s22 = i21 @ s12 + i22 * fd_next[..., jnp.newaxis, :]
+
+    return ScatteringMatrix(
+        s11=s11,
+        s12=s12,
+        s21=s21,
+        s22=s22,
+        start_layer_solve_result=layer_solve_result,
+        start_layer_thickness=layer_thickness,
+        end_layer_solve_result=next_layer_solve_result,
+        end_layer_thickness=next_layer_thickness,
+    )
 
 
 def set_end_layer_thickness(

--- a/src/fmmax/sources.py
+++ b/src/fmmax/sources.py
@@ -398,7 +398,7 @@ def emission_matrix(
     fd_s21_after = utils.diag(next_fd) @ s_matrix_after_source.s21
 
     shape = jnp.broadcast_shapes(q.shape, next_q.shape)
-    eye = utils.diag(jnp.ones(shape))
+    eye = utils.diag(jnp.ones(shape, dtype=q.dtype))
 
     # Equation 7.9 from [1999 Whittaker].
     matrix = jnp.block(

--- a/src/fmmax/utils.py
+++ b/src/fmmax/utils.py
@@ -142,13 +142,14 @@ def _eig_jax(matrix: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     if jax.devices()[0] == jax.devices("cpu")[0]:
         return jnp.linalg.eig(matrix)
     else:
+        dtype = jnp.promote_types(matrix.dtype, jnp.complex64)
         return jax.pure_callback(
             _eig_jax_cpu,
             (
-                jnp.ones(matrix.shape[:-1], dtype=complex),  # Eigenvalues
-                jnp.ones(matrix.shape, dtype=complex),  # Eigenvectors
+                jnp.ones(matrix.shape[:-1], dtype=dtype),  # Eigenvalues
+                jnp.ones(matrix.shape, dtype=dtype),  # Eigenvectors
             ),
-            matrix.astype(complex),
+            matrix.astype(dtype),
             vectorized=True,
         )
 

--- a/src/fmmax/vector.py
+++ b/src/fmmax/vector.py
@@ -483,7 +483,7 @@ def _fourier_loss(
     transverse_wavevectors = basis.transverse_wavevectors(
         primitive_lattice_vectors=primitive_lattice_vectors,
         expansion=expansion,
-        in_plane_wavevector=jnp.zeros((2,)),
+        in_plane_wavevector=jnp.zeros((2,), dtype=fourier_field.real.dtype),
     )
 
     basis_vectors = jnp.stack(

--- a/tests/fmmax/test_beams.py
+++ b/tests/fmmax/test_beams.py
@@ -109,17 +109,17 @@ class RotatedFieldsTest(unittest.TestCase):
             polarization_angle=polarization_angle,
         )
         with self.subTest("ex"):
-            onp.testing.assert_allclose(fields[0][0], expected_fields[0][0], atol=1e-5)
+            onp.testing.assert_allclose(fields[0][0], expected_fields[0][0], atol=2e-5)
         with self.subTest("ey"):
-            onp.testing.assert_allclose(fields[0][1], expected_fields[0][1], atol=1e-5)
+            onp.testing.assert_allclose(fields[0][1], expected_fields[0][1], atol=2e-5)
         with self.subTest("ez"):
-            onp.testing.assert_allclose(fields[0][2], expected_fields[0][2], atol=1e-5)
+            onp.testing.assert_allclose(fields[0][2], expected_fields[0][2], atol=2e-5)
         with self.subTest("hx"):
-            onp.testing.assert_allclose(fields[1][0], expected_fields[1][0], atol=1e-5)
+            onp.testing.assert_allclose(fields[1][0], expected_fields[1][0], atol=2e-5)
         with self.subTest("hy"):
-            onp.testing.assert_allclose(fields[1][1], expected_fields[1][1], atol=1e-5)
+            onp.testing.assert_allclose(fields[1][1], expected_fields[1][1], atol=2e-5)
         with self.subTest("hz"):
-            onp.testing.assert_allclose(fields[1][2], expected_fields[1][2], atol=1e-5)
+            onp.testing.assert_allclose(fields[1][2], expected_fields[1][2], atol=2e-5)
 
     @parameterized.parameterized.expand(
         [


### PR DESCRIPTION
Field generation
- Refactor field generation to provide a function which doesn't require the full layer solve result as an input. This can be beneficial in cases where the full solve result is not available.

Type promotion
- Changes throughout to avoid unwanted type promotion. It should now be possible to carry out 32 bit calculations in 64 bit mode.

Changes related to scattering matrices
- Special function for generating s-matrix for a pair of layers. This is function is computationally cheaper than the existing approach of generating the scattering matrix for a single layer and then extending it.
- Optional argument to s-matrix-generating functions which causes the matrix solve operation to be carried out with 64 bit precision. In some cases, this can help avoid numerical issues associated with 32 bit calculations.